### PR TITLE
feat(api): Add version field to /live endpoint

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -56,6 +56,7 @@ def liveness():
     """Liveness probe: процесс жив (без проверки БД)"""
     return jsonify({
         'status': 'alive',
+        'version': os.getenv('APP_VERSION', '0.2.0'),
         'timestamp': datetime.utcnow().isoformat() + 'Z',
         'uptime_seconds': int(time.time() - app.start_time)
     }), 200


### PR DESCRIPTION
## 🎯 Цель
Добавить информацию о версии API в ответ `/live` для согласованности с `/ready`.

## ✨ Что сделано
- ✅ Добавлено поле `version` в ответ `/live`
- ✅ Значение берётся из `APP_VERSION` (env var)
- ✅ Default значение: `0.2.0`

## 🧪 Тестирование
- ✅ `/live` возвращает корректную версию
- ✅ Формат ответа согласован с `/ready`

## 📋 Связанные задачи
Refs: Sprint 2 - Production readiness