### PR TITLE
fix: Remove SQL comments from query strings

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -941,14 +941,17 @@ def price_history(code: str):
         params.append(to)
 
     where_sql = "WHERE " + " AND ".join(where)
+
+    # Safe: where_sql contains only string constants and %s placeholders.
+    # User data is passed via params to cur.execute(), not concatenated into SQL.
     # nosemgrep: python.flask.security.injection.tainted-sql-string.tainted-sql-string
-    sql = f"""  # Safe: where_sql built from constants, params via psycopg2
+    sql = """
           SELECT price_rub, effective_from, effective_to
           FROM product_prices
-          {where_sql}
+          {}
           ORDER BY effective_from DESC
           LIMIT %s OFFSET %s
-        """
+        """.format(where_sql)
 
     with get_db() as conn, conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
         cur.execute(sql, (*params, limit, offset))
@@ -1068,14 +1071,17 @@ def inventory_history(code: str):
         params.append(to)
 
     where_sql = "WHERE " + " AND ".join(where)
+
+    # Safe: where_sql contains only string constants and %s placeholders.
+    # User data is passed via params to cur.execute(), not concatenated into SQL.
     # nosemgrep: python.flask.security.injection.tainted-sql-string.tainted-sql-string
-    sql = f"""  # Safe: where_sql built from constants, params via psycopg2
+    sql = """
           SELECT stock_total, reserved, stock_free, as_of
           FROM inventory_history
-          {where_sql}
+          {}
           ORDER BY as_of DESC
           LIMIT %s OFFSET %s
-        """
+        """.format(where_sql)
 
     with get_db() as conn, conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
         cur.execute(sql, (*params, limit, offset))


### PR DESCRIPTION
## 🐛 Bug Fix: SQL Injection Antipattern

### Problem
PostgreSQL was receiving Python comments `#` as part of SQL queries, causing:
```
psycopg2.errors.SyntaxError: syntax error at or near "#"
LINE 1:   # Safe: where_sql built from constants...
```

### Root Cause
Comments were placed **inside** SQL triple-quoted strings in functions:
- `price_history()` (line ~944)
- `inventory_history()` (line ~1070)

### Solution
- ✅ Moved comments **outside** SQL strings
- ✅ Replaced f-strings with `.format()` for WHERE clause
- ✅ PostgreSQL now receives clean SQL without Python syntax

### Testing
All endpoints work correctly:
- ✅ `/health` → 200 OK
- ✅ `/sku/<code>/price-history` → 200 OK, returns data
- ✅ `/sku/<code>/inventory-history` → 200 OK, returns data

### Changed Files
- `api/app.py` (2 functions modified)

Closes #3