### PR TITLE
Add data quality gates module and unit tests (Refs #83)

### DIFF
--- a/scripts/data_quality.py
+++ b/scripts/data_quality.py
@@ -1,0 +1,156 @@
+# scripts/data_quality.py
+from __future__ import annotations
+
+"""
+Data quality checks for imported price list data.
+
+Responsibilities:
+    * validate individual rows (код, цены, остатки, abv, объём);
+    * split incoming DataFrame into "good" and "bad" rows;
+    * attach machine-readable error codes to "bad" rows.
+
+This module is intentionally pure-Pandas and does not access DB.
+It can be used from scripts/load_csv.py before upsert_records().
+"""
+
+import re
+from dataclasses import dataclass
+from typing import List, Tuple
+
+import pandas as pd
+
+from scripts.load_utils import _to_float, _to_int
+
+DQ_ERRORS_COLUMN = "__dq_errors"
+
+# Тот же паттерн для кода, что и в load_csv: "похож на артикул"
+CODE_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{2,}$")
+
+
+@dataclass(frozen=True)
+class DataQualityIssue:
+    row_index: int
+    code: str
+    message: str
+
+
+def _is_empty(value) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, float) and pd.isna(value):
+        return True
+    if isinstance(value, str) and value.strip() == "":
+        return True
+    return False
+
+
+def validate_row(row: pd.Series) -> List[str]:
+    """
+    Run data quality checks on a single row and return a list of error codes.
+
+    Error codes (не полный список, можно расширять):
+        * "missing_code"         — пустой или отсутствующий код.
+        * "invalid_code_format"  — код не соответствует артикулу (см. CODE_PATTERN).
+        * "missing_price"        — нет ни одной цены (ни прайс, ни финальная).
+        * "negative_price_list"  — price_rub < 0.
+        * "negative_price_discount" — price_discount < 0.
+        * "negative_stock_total", "negative_reserved", "negative_stock_free".
+        * "invalid_abv_range"    — abv < 0 или > 100.
+        * "invalid_volume"       — volume <= 0.
+    """
+    errors: List[str] = []
+
+    # --- Код ---
+    code = row.get("code")
+    if _is_empty(code):
+        errors.append("missing_code")
+    else:
+        code_str = str(code).strip()
+        if not CODE_PATTERN.match(code_str):
+            errors.append("invalid_code_format")
+
+    # --- Цены ---
+    price_rub = _to_float(row.get("price_rub")) if "price_rub" in row else None
+    price_disc = _to_float(row.get("price_discount")) if "price_discount" in row else None
+
+    if price_rub is None and price_disc is None:
+        # если есть хотя бы одна из колонок, но обе пустые/невалидные
+        if "price_rub" in row or "price_discount" in row:
+            errors.append("missing_price")
+    else:
+        if price_rub is not None and price_rub < 0:
+            errors.append("negative_price_list")
+        if price_disc is not None and price_disc < 0:
+            errors.append("negative_price_discount")
+
+    # --- Остатки ---
+    for col, err_code in (
+        ("stock_total", "negative_stock_total"),
+        ("reserved", "negative_reserved"),
+        ("stock_free", "negative_stock_free"),
+    ):
+        if col in row:
+            v = _to_int(row.get(col))
+            if v is not None and v < 0:
+                errors.append(err_code)
+
+    # --- ABV ---
+    if "abv" in row:
+        abv = _to_float(row.get("abv"))
+        if abv is not None and not (0.0 <= abv <= 100.0):
+            errors.append("invalid_abv_range")
+
+    # --- Объём ---
+    if "volume" in row:
+        vol = _to_float(row.get("volume"))
+        if vol is not None and vol <= 0.0:
+            errors.append("invalid_volume")
+
+    return errors
+
+
+def apply_quality_gates(df: pd.DataFrame) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    """
+    Split DataFrame into "good" and "bad" rows according to data quality rules.
+
+    Returns:
+        good_df, bad_df
+
+    Where:
+        * good_df — копия исходных строк без ошибок;
+        * bad_df  — копия строк с ошибками + колонка DQ_ERRORS_COLUMN
+                    (список строковых error code'ов для каждой строки).
+    """
+    if df.empty:
+        # Пустой вход — оба фрейма пустые с одинаковыми колонками
+        good_empty = df.copy()
+        bad_empty = df.copy()
+        if DQ_ERRORS_COLUMN not in bad_empty.columns:
+            bad_empty[DQ_ERRORS_COLUMN] = []
+        return good_empty, bad_empty
+
+    good_indices: List[int] = []
+    bad_indices: List[int] = []
+    row_errors: List[List[str]] = []
+
+    # Проходим по строкам и собираем ошибки
+    for idx, row in df.iterrows():
+        errs = validate_row(row)
+        if errs:
+            bad_indices.append(idx)
+            row_errors.append(errs)
+        else:
+            good_indices.append(idx)
+
+    # good_df
+    good_df = df.loc[good_indices].copy() if good_indices else df.head(0).copy()
+
+    # bad_df
+    if bad_indices:
+        bad_df = df.loc[bad_indices].copy()
+        bad_df[DQ_ERRORS_COLUMN] = row_errors
+    else:
+        bad_df = df.head(0).copy()
+        bad_df[DQ_ERRORS_COLUMN] = []
+
+    return good_df, bad_df

--- a/tests/unit/test_data_quality.py
+++ b/tests/unit/test_data_quality.py
@@ -1,0 +1,157 @@
+import os
+import sys
+from datetime import date
+
+import pandas as pd
+import pytest
+
+# Добавляем путь к корню репо, чтобы импортировать scripts.*
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from scripts.data_quality import DQ_ERRORS_COLUMN, apply_quality_gates
+
+
+@pytest.mark.unit
+def test_apply_quality_gates_all_good():
+    """
+    Если все строки валидные, bad_df должен быть пустым, а good_df содержать все строки.
+    """
+    df = pd.DataFrame(
+        [
+            {
+                "code": "ABC123",
+                "price_rub": 100.0,
+                "price_discount": 90.0,
+                "stock_total": 10,
+                "reserved": 0,
+                "stock_free": 10,
+                "abv": 13.5,
+                "volume": 0.75,
+            },
+            {
+                "code": "XYZ_999",
+                "price_rub": 500.0,
+                "price_discount": None,
+                "stock_total": 0,
+                "reserved": 0,
+                "stock_free": 0,
+                "abv": 40.0,
+                "volume": 0.5,
+            },
+        ]
+    )
+
+    good_df, bad_df = apply_quality_gates(df)
+
+    # good_df содержит все строки, bad_df пустой
+    assert len(good_df) == 2
+    assert len(bad_df) == 0
+    assert DQ_ERRORS_COLUMN in bad_df.columns
+    # good_df не обязан содержать колонку с ошибками
+    assert DQ_ERRORS_COLUMN not in good_df.columns
+
+
+@pytest.mark.unit
+def test_apply_quality_gates_missing_code_and_negative_price():
+    """
+    Строка с пустым кодом и отрицательной ценой должна попасть в bad_df
+    с ошибками 'missing_code' и 'negative_price_list'.
+    """
+    df = pd.DataFrame(
+        [
+            {
+                "code": "GOOD1",
+                "price_rub": 100.0,
+                "price_discount": 90.0,
+            },
+            {
+                "code": "   ",  # пустой/whitespace код
+                "price_rub": -10.0,
+                "price_discount": None,
+            },
+        ]
+    )
+
+    good_df, bad_df = apply_quality_gates(df)
+
+    # Одна хорошая, одна плохая
+    assert len(good_df) == 1
+    assert len(bad_df) == 1
+
+    errors = bad_df.iloc[0][DQ_ERRORS_COLUMN]
+    assert isinstance(errors, list)
+    assert "missing_code" in errors
+    assert "negative_price_list" in errors
+
+
+@pytest.mark.unit
+def test_apply_quality_gates_invalid_code_pattern():
+    """
+    Код, не проходящий паттерн артикула (с пробелами/спецсимволами),
+    должен помечаться как 'invalid_code_format'.
+    """
+    df = pd.DataFrame(
+        [
+            {
+                "code": "OK_123",
+                "price_rub": 100.0,
+            },
+            {
+                "code": "A 1",  # пробел, не подходит под паттерн
+                "price_rub": 100.0,
+            },
+        ]
+    )
+
+    good_df, bad_df = apply_quality_gates(df)
+
+    # Первая строка должна быть в good_df, вторая — в bad_df
+    assert len(good_df) == 1
+    assert len(bad_df) == 1
+
+    errors = bad_df.iloc[0][DQ_ERRORS_COLUMN]
+    assert "invalid_code_format" in errors
+
+
+@pytest.mark.unit
+def test_apply_quality_gates_invalid_abv_and_volume_and_stock():
+    """
+    Проверяем несколько типов ошибок одновременно:
+      - abv вне диапазона [0, 100];
+      - volume <= 0;
+      - отрицательные остатки.
+    """
+    df = pd.DataFrame(
+        [
+            {
+                "code": "GOOD_OK",
+                "price_rub": 100.0,
+                "abv": 13.5,
+                "volume": 0.75,
+                "stock_total": 10,
+                "reserved": 0,
+                "stock_free": 10,
+            },
+            {
+                "code": "BAD_1",
+                "price_rub": 100.0,
+                "abv": 150.0,   # слишком большой градус
+                "volume": 0.0,  # нулевой объём
+                "stock_total": -1,
+                "reserved": -2,
+                "stock_free": -3,
+            },
+        ]
+    )
+
+    good_df, bad_df = apply_quality_gates(df)
+
+    assert len(good_df) == 1
+    assert len(bad_df) == 1
+
+    errors = bad_df.iloc[0][DQ_ERRORS_COLUMN]
+    assert "invalid_abv_range" in errors
+    assert "invalid_volume" in errors
+    assert "negative_stock_total" in errors
+    assert "negative_reserved" in errors
+    assert "negative_stock_free" in errors


### PR DESCRIPTION
## Кратко

Добавлен модуль для проверки качества данных прайс-листа и базовые юнит-тесты.

- Новый модуль `scripts/data_quality.py` реализует проверки качества данных (data quality gates) перед импортом.
- Новый набор тестов `tests/unit/test_data_quality.py` фиксирует базовые правила валидации и защиту от регрессий.
- Модуль пока не интегрирован в ETL-пайплайн (`load_csv.py` / `upsert_records`), это делается отдельным шагом в рамках задачи #83.

---

## Что добавлено

### 1. Модуль `scripts/data_quality.py`

**Назначение:**

Отдельный, чистый от побочных эффектов слой проверок качества данных для импортируемого прайс-листа.  
Модуль не ходит в БД и не знает об idempotency — он работает только с `pandas.DataFrame` и может вызываться из `scripts/load_csv.py` до этапа `upsert_records()`.

**Основное содержимое:**

- Константа `DQ_ERRORS_COLUMN = "__dq_errors"` — имя служебной колонки с ошибками в «плохих» строках.
- Паттерн артикула `CODE_PATTERN`, согласованный по смыслу с логикой фильтрации кодов в `load_csv.py`.
- Класс `DataQualityIssue` (dataclass) — задел на дальнейшую детализацию хранения ошибок.
- Вспомогательная функция `_is_empty(value)` для единообразной проверки «пустых» значений.

#### Функция `validate_row(row: pd.Series) -> List[str>`

Проверяет одну строку и возвращает список строковых error code’ов. В текущей версии реализованы проверки:

- `missing_code` — код пустой или отсутствует.
- `invalid_code_format` — код не соответствует ожидаемому паттерну артикула (`^[A-Za-z0-9][A-Za-z0-9_-]{2,}$`).
- `missing_price` — нет ни одной валидной цены (`price_rub` и `price_discount` одновременно пусты или нечисловые).
- `negative_price_list` — `price_rub < 0`.
- `negative_price_discount` — `price_discount < 0`.
- `negative_stock_total`, `negative_reserved`, `negative_stock_free` — отрицательные остатки.
- `invalid_abv_range` — `abv` вне диапазона `[0, 100]`.
- `invalid_volume` — `volume <= 0`.

Функция опирается на существующие хелперы из `scripts.load_utils`:

- `_to_float` — для мягкого приведения к `float`;
- `_to_int` — для мягкого приведения к `int`.

#### Функция `apply_quality_gates(df: pd.DataFrame) -> Tuple[pd.DataFrame, pd.DataFrame]`

Разделяет входной DataFrame на две части: «хорошие» и «плохие» строки.

Возвращает кортеж:

- `good_df` — все строки, для которых `validate_row()` не вернул ни одной ошибки;
- `bad_df` — все строки с ошибками + колонка `__dq_errors`, содержащая список error code’ов для каждой строки.

Особенности:

- Пустой входной DataFrame обрабатывается корректно: оба возвращаемых DataFrame пустые, но структура колонок сохраняется, а в `bad_df` присутствует колонка `__dq_errors`.
- Модуль не принимает решений о том, **что делать** с плохими строками (отклонить весь импорт, отправить в карантин и т.п.) — это ответственность вызывающей стороны (например, `load_csv.py` и последующих задач #83/84).

---

### 2. Тесты `tests/unit/test_data_quality.py`

Добавлен новый набор юнит-тестов, который покрывает базовый функционал модуля:

1. `test_apply_quality_gates_all_good`  
   - Все строки валидны → `good_df` содержит все строки, `bad_df` пустой.  
   - Проверяется наличие колонки `__dq_errors` в `bad_df` и её отсутствие в `good_df`.

2. `test_apply_quality_gates_missing_code_and_negative_price`  
   - Одна строка валидна, другая с пустым кодом и отрицательной ценой.  
   - Ожидается одна ошибка в `bad_df` с кодами `missing_code` и `negative_price_list`.

3. `test_apply_quality_gates_invalid_code_pattern`  
   - Одна строка с нормальным кодом, другая с кодом, не проходящим паттерн (с пробелом).  
   - В `bad_df` ошибка `invalid_code_format`.

4. `test_apply_quality_gates_invalid_abv_and_volume_and_stock`  
   - Проверка сразу нескольких видов ошибок:
     - `invalid_abv_range` (градус выше 100);
     - `invalid_volume` (нулевой объём);
     - отрицательные остатки (`negative_stock_total`, `negative_reserved`, `negative_stock_free`).

Все тесты проходят:

```bash
pytest tests/unit/test_data_quality.py -q
pytest -q
```

На момент создания PR общее количество тестов: **152 passed**.

---

## Что дальше (в рамках #83)

Данный PR выполняет первый шаг по задаче #83 — создание отдельного слоя data quality с тестами.  
Следующие шаги планируются в отдельных изменениях:

- интеграция `apply_quality_gates(df)` в `scripts/load_csv.py` перед вызовом `upsert_records(...)`;
- логирование количества и типов ошибок;
- возможное последующее сохранение «плохих» строк в карантинную таблицу (связано с задачей #84).

PR помечен как:

**Refs #83**
