### PR TITLE
ops: add manual smoke check and update structure docs

### DIFF
--- a/docs/manual-smoke-check.md
+++ b/docs/manual-smoke-check.md
@@ -36,195 +36,113 @@ API_KEY="<ВСТАВЬ_СЮДА_API_KEY>"
 
 ### 1.1. /live
 
-**PowerShell**
-
 ```powershell
 Invoke-RestMethod "$baseUrl/live"
 ```
 
-Ожидаем:
-- `status = "alive"`
-- `version` совпадает с текущим релизом (например, `0.4.3`).
-
-**curl**
-
-```bash
-curl "$BASE_URL/live"
-```
-
----
-
 ### 1.2. /ready
-
-**PowerShell**
 
 ```powershell
 Invoke-RestMethod "$baseUrl/ready"
 ```
 
-Ожидаем:
-- `status = "ready"`
-- в `checks.database` нет ошибок.
-
----
-
 ### 1.3. /health
-
-**PowerShell**
 
 ```powershell
 Invoke-RestMethod "$baseUrl/health"
 ```
 
-Ожидаем:
-- ответ `ok` / `True` (в зависимости от формата).
-
 ---
 
 ## 2. Базовый поиск по каталогу
-
-### 2.1. Поиск 3 товаров
-
-**PowerShell**
 
 ```powershell
 $search = Invoke-RestMethod "$baseUrl/api/v1/products/search?limit=3" -Headers $headers
 $search.items | Select-Object code, name, price_final_rub | Format-Table
 ```
 
-Ожидаем:
-- `items` не пустой;
-- у каждого товара есть `code`, `name`, `price_final_rub`;
-- поля enrichment: `producer_site`, `image_url`, `winery_name_ru`, `winery_description_ru` присутствуют в объекте.
-
-**curl (только посмотреть «сырое» тело)**
-
-```bash
-curl -H "X-API-Key: $API_KEY"   "$BASE_URL/api/v1/products/search?limit=3"
-```
-
 ---
 
 ## 3. SKU API + history
 
-### 3.1. Карточка SKU
-
-Выбираем любой код из поиска:
+### 3.1. Получение SKU
 
 ```powershell
 $code = $search.items[0].code
-$code
+Invoke-RestMethod "$baseUrl/api/v1/sku/$code" -Headers $headers
 ```
-
-Запрашиваем SKU:
-
-```powershell
-$sku = Invoke-RestMethod "$baseUrl/api/v1/sku/$code" -Headers $headers
-$sku
-```
-
-Ожидаем:
-- те же поля, что в поиске;
-- дополнительно: `supplier_ru`, `title_ru`, `winery_description_ru` и т.п.
-
----
 
 ### 3.2. История цен
 
 ```powershell
-$priceHistory = Invoke-RestMethod `
-  "$baseUrl/api/v1/sku/$code/price-history?from=2025-01-01&to=2025-12-31&limit=50" `
-  -Headers $headers
-
-$priceHistory
+Invoke-RestMethod "$baseUrl/api/v1/sku/$code/price-history?from=2025-01-01&to=2025-12-31&limit=50" -Headers $headers
 ```
-
-Ожидаем:
-- `code` совпадает с `$code`;
-- `items` — список записей с `effective_from`, `effective_to`, `price_rub`.
-
----
 
 ### 3.3. История остатков
 
 ```powershell
-$invHistory = Invoke-RestMethod `
-  "$baseUrl/api/v1/sku/$code/inventory-history?from=2025-01-01&to=2025-12-31&limit=50" `
-  -Headers $headers
-
-$invHistory
+Invoke-RestMethod "$baseUrl/api/v1/sku/$code/inventory-history?from=2025-01-01&to=2025-12-31&limit=50" -Headers $headers
 ```
-
-Ожидаем:
-- запрос не падает с ошибкой;
-- `code` совпадает с `$code`;
-- `items` либо пустой объект, либо список записей (в зависимости от наличия данных).
 
 ---
 
 ## 4. Экспорт (JSON-режим)
 
-Чтобы не создавать файлы, для smoke-теста используем формат `json`.
-
 ### 4.1. Экспорт поиска
 
 ```powershell
-$exportSearch = Invoke-RestMethod `
-  "$baseUrl/api/v1/export/search?format=json&limit=3" `
-  -Headers $headers
-
-$exportSearch | Select-Object -First 1
+Invoke-RestMethod "$baseUrl/api/v1/export/search?format=json&limit=3" -Headers $headers
 ```
-
-Ожидаем:
-- структура аналогична поиску, но в «экспортном» формате;
-- нет ошибок и статус HTTP 200.
-
----
 
 ### 4.2. Экспорт SKU
 
 ```powershell
-$exportSku = Invoke-RestMethod `
-  "$baseUrl/api/v1/export/sku/$code?format=json" `
-  -Headers $headers
-
-$exportSku
+Invoke-RestMethod "$baseUrl/api/v1/export/sku/$code?format=json" -Headers $headers
 ```
-
-Ожидаем:
-- та же информация, что и в `/api/v1/sku/$code`;
-- пригодно для генерации PDF-карточки.
-
----
 
 ### 4.3. Экспорт истории цен
 
 ```powershell
-$exportPriceHistory = Invoke-RestMethod `
-  "$baseUrl/api/v1/export/price-history/$code?format=json" `
-  -Headers $headers
-
-$exportPriceHistory
+Invoke-RestMethod "$baseUrl/api/v1/export/price-history/$code?format=json" -Headers $headers
 ```
-
-Ожидаем:
-- структура как у эндпоинта `/price-history`, но в экспортном формате;
-- запрос отрабатывает без ошибок.
 
 ---
 
 ## 5. Критерии успешного smoke-теста
 
-Smoke-тест считаем **успешным**, если:
-
 1. `/live`, `/ready`, `/health` возвращают ожидаемые статусы.
-2. Поиск по каталогу (`/products/search`) выдаёт хотя бы один товар.
-3. SKU-эндпоинт и история цен/остатков по выбранному SKU работают.
-4. Все экспортные эндпоинты (`/export/...`) отвечают с HTTP 200 и валидным JSON.
-5. Нигде не получаем HTTP 5xx или неожиданные исключения.
+2. Поиск (`/products/search`) возвращает не пустой список.
+3. SKU и history работают без ошибок.
+4. Экспортные эндпоинты возвращают корректный JSON.
+5. Нет HTTP 5xx и неожиданных исключений.
 
-Если какой-то шаг падает, фиксируем:
-- какой именно запрос;
-- HTTP-статус и текст ошибки;
-и заводим Issue в репозитории.
+---
+
+## 6. Быстрый чек-лист на будущее (URL и PowerShell)
+
+Когда что-то странное на уровне URL (например, `/sku/=json`):
+
+### 1. Всегда печатай URL перед запросом
+
+```powershell
+$exportUrl = "$baseUrl/api/v1/export/sku/$code?format=json"
+$exportUrl
+```
+
+### 2. Если видишь «пустой» SKU в URL
+
+```powershell
+"sku = [$code]"
+```
+
+Если там пусто — переприсвой переменную вручную.
+
+### 3. Для строк с параметрами в PowerShell всегда безопасно писать так:
+
+```powershell
+"$baseUrl/api/v1/export/sku/$($code)?format=json"
+```
+
+Использование `$($code)` исключает неочевидное поведение интерполяции.
+
+---

--- a/project-structure-auto.txt
+++ b/project-structure-auto.txt
@@ -30,6 +30,7 @@ wine-assistant/
     CACHEDIR.TAG
  api/
     app.py
+    export.py
     logging_config.py
     request_middleware.py
     schemas.py
@@ -38,16 +39,16 @@ wine-assistant/
  data/
     archive/
     inbox/
-       2025_06_03 Прайс_Легенда_Виноделия.xlsx
-       2025_06_25 Прайс_Легенда_Виноделия.xlsx
-       2025_08_06 Прайс_Легенда_Виноделия.xlsx
-       2025_08_19 Прайс_Легенда_Виноделия.xlsx
-       2025_09_29 Прайс_Легенда_Виноделия.xlsx
-       2025_10_22 Прайс_Легенда_Виноделия.xlsx
-       2025_10_27 Прайс_Легенда_Виноделия.xlsx
-       Копия 2025_01_20 Прайс_Легенда_Виноделия.xlsx
+       2025_06_03 РџСЂР°Р№СЃ_Р›РµРіРµРЅРґР°_Р’РёРЅРѕРґРµР»РёСЏ.xlsx
+       2025_06_25 РџСЂР°Р№СЃ_Р›РµРіРµРЅРґР°_Р’РёРЅРѕРґРµР»РёСЏ.xlsx
+       2025_08_06 РџСЂР°Р№СЃ_Р›РµРіРµРЅРґР°_Р’РёРЅРѕРґРµР»РёСЏ.xlsx
+       2025_08_19 РџСЂР°Р№СЃ_Р›РµРіРµРЅРґР°_Р’РёРЅРѕРґРµР»РёСЏ.xlsx
+       2025_09_29 РџСЂР°Р№СЃ_Р›РµРіРµРЅРґР°_Р’РёРЅРѕРґРµР»РёСЏ.xlsx
+       2025_10_22 РџСЂР°Р№СЃ_Р›РµРіРµРЅРґР°_Р’РёРЅРѕРґРµР»РёСЏ.xlsx
+       2025_10_27 РџСЂР°Р№СЃ_Р›РµРіРµРЅРґР°_Р’РёРЅРѕРґРµР»РёСЏ.xlsx
+       РљРѕРїРёСЏ 2025_01_20 РџСЂР°Р№СЃ_Р›РµРіРµРЅРґР°_Р’РёРЅРѕРґРµР»РёСЏ.xlsx
     sample/
-        dw_sample_products.csv
+       dw_sample_products.csv
  db/
     migrations/
        0000_schema_migrations.sql
@@ -55,7 +56,7 @@ wine-assistant/
        0002_price-history-guardrails.sql
        0003_inventory-columns-and-asof.sql
        0004_diagnostics.sql
-       0005_price-check.sql
+       0005-price-check.sql
        0006_add-idempotency-tables.sql
        0007_schema-migrations-view.sql
        0008_schema-migrations-view.sql
@@ -89,6 +90,7 @@ wine-assistant/
        README-before21112025.md
        README-before22112025.md
     dev-checklist.ps1
+    manual-smoke-check.md
     pr-93-summary.md
     requirements.md
     roadmap_sprint7+.md
@@ -110,6 +112,7 @@ wine-assistant/
     load_csv.py
     load_utils.py
     migrate.ps1
+    manual_smoke_check.ps1
     run_integration_tests.ps1
     setup_scheduler.ps1
  tests/
@@ -143,7 +146,7 @@ wine-assistant/
     test_api_products_happy.py
     test_api_products_validation.py
     test_api_search_validation.py
-  .dockerignore
+ .dockerignore
  .coveragerc
  .env
  .env.example

--- a/project-structure.txt
+++ b/project-structure.txt
@@ -50,6 +50,7 @@ wine-assistant/
 │   │   ├── README-before*.md         # Снапшоты README во времени
 │   │   └── ...                       # Прочие рабочие заметки
 │   ├── dev-checklist.ps1             # Скрипт/чеклист для ежедневной dev-рутины [INTERNAL]
+│   ├── manual-smoke-check.md         # Пошаговая инструкция для ручного smoke-теста API [INTERNAL]
 │   ├── pr-93-summary.md              # Конспект по PR #93 (для истории) [INTERNAL]
 │   ├── requirements.md               # Функциональные/тех. требования к системе [PUBLIC API]
 │   ├── roadmap_sprint7+.md           # Ранняя дорожная карта [INTERNAL][EXPERIMENTAL]
@@ -74,7 +75,8 @@ wine-assistant/
 │   ├── load_utils.py                 # Общие утилиты для сценариев загрузки [INTERNAL]
 │   ├── migrate.ps1                   # Удобный запуск миграций под Windows [INTERNAL]
 │   ├── run_integration_tests.ps1     # Скрипт запуска интеграционных тестов [INTERNAL]
-│   └── setup_scheduler.ps1           # Настройка планировщика задач (Windows) [INTERNAL]
+│   ├── setup_scheduler.ps1           # Настройка планировщика задач (Windows) [INTERNAL]
+│   └── manual_smoke_check.ps1        # Автоматический smoke-check API (PowerShell, health/search/SKU/export) [INTERNAL]
 
 ├── tests/                            # Автотесты (API, ETL, утилиты) [INTERNAL]
 │   ├── README.md                     # Пояснения к структуре и уровням тестирования [INTERNAL]

--- a/scripts/manual_smoke_check.ps1
+++ b/scripts/manual_smoke_check.ps1
@@ -1,0 +1,167 @@
+param(
+    [string]$BaseUrl = "http://localhost:18000",
+    [string]$ApiKey  = $env:API_KEY
+)
+
+if (-not $ApiKey -or $ApiKey.Trim() -eq "") {
+    Write-Host "[ERROR] API key is not set. Please set API_KEY env var or pass -ApiKey." -ForegroundColor Red
+    exit 1
+}
+
+$headers = @{ "X-API-Key" = $ApiKey }
+
+$results = @()
+
+function Test-Endpoint {
+    param(
+        [string]$Name,
+        [string]$Url,
+        [hashtable]$Headers = $null,
+        [switch]$Optional,
+        [scriptblock]$Validate = $null
+    )
+
+    Write-Host ("==> Checking {0}: {1}" -f $Name, $Url)
+
+    $success = $false
+    $message = ""
+    $status  = $null
+
+    try {
+        if ($Headers) {
+            $resp = Invoke-RestMethod -Uri $Url -Headers $Headers -TimeoutSec 10
+        } else {
+            $resp = Invoke-RestMethod -Uri $Url -TimeoutSec 10
+        }
+
+        $success = $true
+        $status  = 200
+
+        if ($Validate) {
+            $validationResult = & $Validate $resp
+            if (-not $validationResult.Success) {
+                $success = $false
+                $message = $validationResult.Message
+            }
+        }
+
+        if ($success) {
+            Write-Host "   OK" -ForegroundColor Green
+        } else {
+            Write-Host ("   FAIL: {0}" -f $message) -ForegroundColor Yellow
+        }
+    }
+    catch {
+        $success = $false
+        $message = $_.Exception.Message
+        if ($_.Exception.Response -and $_.Exception.Response.StatusCode) {
+            $status = [int]$_.Exception.Response.StatusCode
+        }
+        Write-Host ("   ERROR: {0}" -f $message) -ForegroundColor Red
+    }
+
+    $results += [pscustomobject]@{
+        Name     = $Name
+        Url      = $Url
+        Success  = $success
+        Optional = [bool]$Optional
+        Message  = $message
+        Status   = $status
+    }
+}
+
+# 1. Health / liveness / readiness
+Test-Endpoint -Name "live"  -Url "$BaseUrl/live"  -Validate {
+    param($resp)
+    $ok = $resp.status -eq "alive"
+    if ($ok) {
+        return [pscustomobject]@{ Success = $true;  Message = "" }
+    } else {
+        return [pscustomobject]@{ Success = $false; Message = ("status is '{0}'" -f $resp.status) }
+    }
+}
+
+Test-Endpoint -Name "ready" -Url "$BaseUrl/ready" -Validate {
+    param($resp)
+    $ok = $resp.status -eq "ready"
+    if ($ok) {
+        return [pscustomobject]@{ Success = $true;  Message = "" }
+    } else {
+        return [pscustomobject]@{ Success = $false; Message = ("status is '{0}'" -f $resp.status) }
+    }
+}
+
+Test-Endpoint -Name "health" -Url "$BaseUrl/health" -Validate {
+    param($resp)
+    $ok = ($resp -eq $true) -or ("$resp" -match "ok")
+    if ($ok) {
+        return [pscustomobject]@{ Success = $true;  Message = "" }
+    } else {
+        return [pscustomobject]@{ Success = $false; Message = ("unexpected health response '{0}'" -f $resp) }
+    }
+}
+
+# 2. Search
+Test-Endpoint -Name "products.search" -Url "$BaseUrl/api/v1/products/search?limit=3" -Headers $headers -Validate {
+    param($resp)
+    $hasItems = $resp.items -and $resp.items.Count -gt 0
+    if ($hasItems) {
+        return [pscustomobject]@{ Success = $true;  Message = "" }
+    } else {
+        return [pscustomobject]@{ Success = $false; Message = "no items returned" }
+    }
+}
+
+# 3. SKU + history (using first code from search)
+$skuCode = $null
+try {
+    $search = Invoke-RestMethod -Uri "$BaseUrl/api/v1/products/search?limit=3" -Headers $headers -TimeoutSec 10
+    if ($search.items -and $search.items.Count -gt 0) {
+        $skuCode = $search.items[0].code
+        Write-Host ("Using SKU code from search: {0}" -f $skuCode)
+    } else {
+        Write-Host "[WARN] Search returned no items, skipping SKU/history checks." -ForegroundColor Yellow
+    }
+}
+catch {
+    Write-Host ("[WARN] Could not perform initial search for SKU, skipping SKU/history checks: {0}" -f $_.Exception.Message) -ForegroundColor Yellow
+}
+
+if ($skuCode) {
+    Test-Endpoint -Name "sku" -Url "$BaseUrl/api/v1/sku/$skuCode" -Headers $headers
+
+    Test-Endpoint -Name "price-history" -Url "$BaseUrl/api/v1/sku/$skuCode/price-history?from=2025-01-01&to=2025-12-31&limit=50" -Headers $headers -Optional
+
+    Test-Endpoint -Name "inventory-history" -Url "$BaseUrl/api/v1/sku/$skuCode/inventory-history?from=2025-01-01&to=2025-12-31&limit=50" -Headers $headers -Optional
+}
+
+# 4. Export (JSON mode)
+Test-Endpoint -Name "export.search.json" -Url "$BaseUrl/export/search?format=json&limit=3" -Headers $headers
+
+if ($skuCode) {
+    # Export SKU card as JSON (required)
+    $exportSkuUrl = "$BaseUrl/export/sku/$($skuCode)?format=json"
+    Test-Endpoint -Name "export.sku.json" -Url $exportSkuUrl -Headers $headers
+
+    # Export price history as JSON (optional)
+    $exportPriceHistoryUrl = "$BaseUrl/export/price-history/$($skuCode)?format=json"
+    Test-Endpoint -Name "export.price-history.json" -Url $exportPriceHistoryUrl -Headers $headers -Optional
+}
+
+
+Write-Host ""
+Write-Host "==== SMOKE SUMMARY ===="
+
+$results | Format-Table Name, Success, Optional, Status, Message -AutoSize
+
+$hardFailures = $results | Where-Object { -not $_.Success -and -not $_.Optional }
+
+if ($hardFailures.Count -gt 0) {
+    Write-Host ""
+    Write-Host "[FAIL] Smoke-check finished with errors (required endpoints failed)." -ForegroundColor Red
+    exit 1
+} else {
+    Write-Host ""
+    Write-Host "[OK] Smoke-check passed (all required endpoints are healthy)." -ForegroundColor Green
+    exit 0
+}


### PR DESCRIPTION
This PR adds a small ops/monitoring bundle:

- `docs/manual-smoke-check.md` — пошаговый сценарий ручного smoke-теста:
  - /live, /ready, /health
  - базовый поиск по каталогу
  - SKU + price-history + inventory-history
  - экспорт в формате json (поиск, SKU, история цен)
  - быстрый чек-лист по отладке URL в PowerShell.

- `scripts/manual_smoke_check.ps1` — автоматический smoke-скрипт:
  - проверяет health/live/ready
  - делает search + SKU + history
  - проверяет export (search / SKU / price-history)
  - отдаёт exit 0 / exit 1, что удобно для Task Scheduler/CI.

- `project-structure.txt` / `project-structure-auto.txt`:
  - актуализирована структура проекта под новые docs + scripts.
