### PR TITLE
ci: add migration lint and stabilize db env wiring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,25 +7,48 @@ on:
     branches: [ master ]
   workflow_dispatch:
 
-# Не даём двум джобам (push и PR одного и того же бранча) идти параллельно
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
+  migration_lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Validate migrations layout
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+          python scripts/check_migrations.py
+
   tests:
+    needs: migration_lint
     runs-on: ubuntu-latest
 
     env:
       PYTHONUTF8: "1"
       PYTHONIOENCODING: "utf-8"
       TZ: Europe/Moscow
-      # Подключение к БД с хоста раннера (порт публикуем 5432:5432 в compose)
+      # DB for docker-compose (published port)
+      DB_PORT_OUT: 15432
+      # DB for migrate.sh / scripts / psql on host
       DB_HOST: 127.0.0.1
       DB_PORT: 15432
       DB_USER: postgres
       DB_PASSWORD: dev_local_pw
       DB_NAME: wine_db
+      # these are for postgres container
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: dev_local_pw
+      POSTGRES_DB: wine_db
       RUN_DB_TESTS: "1"
 
     steps:
@@ -37,7 +60,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.11"
 
       - name: Install system deps (psql client)
         run: |
@@ -56,8 +79,9 @@ jobs:
       - name: Wait for DB readiness
         shell: bash
         run: |
+          set -Eeuo pipefail
           for i in {1..90}; do
-            if pg_isready -h "${DB_HOST}" -p "${DB_PORT}" >/dev/null 2>&1; then
+            if pg_isready -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" -d "${DB_NAME}" >/dev/null 2>&1; then
               echo "DB is ready"; exit 0
             fi
             sleep 1
@@ -66,11 +90,23 @@ jobs:
           docker compose logs db
           exit 1
 
-      - name: Apply SQL migrations
+      - name: Apply SQL migrations (idempotency check)
         env:
-          # на всякий случай прокидываем пароль и здесь
           PGPASSWORD: ${{ env.DB_PASSWORD }}
-        run: bash db/migrate.sh
+        shell: bash
+        run: |
+          set -Eeuo pipefail
+
+          bash db/migrate.sh
+          c1=$(psql -X -tA -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" -d "${DB_NAME}" -c "select count(*) from public.schema_migrations;")
+
+          bash db/migrate.sh
+          c2=$(psql -X -tA -h "${DB_HOST}" -p "${DB_PORT}" -U "${DB_USER}" -d "${DB_NAME}" -c "select count(*) from public.schema_migrations;")
+
+          if [[ "${c1}" != "${c2}" ]]; then
+            echo "::error::migrate.sh is not idempotent: schema_migrations count changed ${c1} -> ${c2}"
+            exit 1
+          fi
 
       - name: Run tests
         run: pytest -q -m "not monitoring"

--- a/scripts/check_migrations.py
+++ b/scripts/check_migrations.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+RE_ALLOWED_CANONICAL = re.compile(r"^\d{4}_.+\.sql$", re.IGNORECASE)
+RE_DATE_STYLE = re.compile(r"^\d{4}-\d{2}-\d{2}-", re.IGNORECASE)
+
+def main() -> int:
+    repo_root = Path(__file__).resolve().parents[1]
+    migrations_dir = repo_root / "db" / "migrations"
+
+    if not migrations_dir.exists():
+        print(f"[check_migrations] ERROR: not found: {migrations_dir}")
+        return 2
+
+    violations: list[str] = []
+
+    for path in migrations_dir.rglob("*.sql"):
+        rel = path.relative_to(migrations_dir)
+        parts = rel.parts
+
+        # allow anything under _legacy (including nested dirs)
+        if parts and parts[0] == "_legacy":
+            continue
+
+        # canonical migrations MUST be directly under db/migrations (no extra subdirs)
+        if len(parts) != 1:
+            violations.append(f"{rel.as_posix()} (canonical migrations must be in db/migrations root; only _legacy/ may be a subdir)")
+            continue
+
+        filename = path.name
+
+        if RE_DATE_STYLE.match(filename):
+            violations.append(f"{rel.as_posix()} (date-based legacy file must be under _legacy/)")
+            continue
+
+        if not RE_ALLOWED_CANONICAL.match(filename):
+            violations.append(f"{rel.as_posix()} (invalid canonical migration name; expected NNNN_*.sql)")
+            continue
+
+    if violations:
+        print("[check_migrations] ERROR: migration layout violations found:")
+        for v in violations:
+            print(f" - {v}")
+        print("\nRules:")
+        print(" - Canonical migrations MUST be db/migrations/NNNN_*.sql (root only)")
+        print(" - Legacy scripts MUST be placed under db/migrations/_legacy/")
+        return 1
+
+    print("[check_migrations] OK")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

Устраняем риск повторного применения/смешивания миграций и флак CI из-за неявной/рассинхронизированной прокидки переменных окружения для БД.

## What changed

- Добавлен `migration_lint` job: валидация структуры и нейминга миграций (канонические `db/migrations/NNNN_*.sql`, legacy — только в `db/migrations/_legacy/`).
- Сделана явная и однозначная прокидка DB env в CI (host-side `DB_*` + согласованные `POSTGRES_*` для контейнера).
- Добавлена проверка идемпотентности `db/migrate.sh` (двойной прогон в CI и контроль, что повторный запуск не меняет состояние).
- Добавлен скрипт `scripts/check_migrations.py` для локальной проверки правил миграций.

## How to test

- Убедиться, что CI прошёл успешно.
- Локально:
  - `python scripts/check_migrations.py`

## Links

- Closes #156
- Refs #153
