### PR TITLE
PR-1: Import Runs Registry (import_runs journal + retry blocking)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-* text=auto
+* text=auto eol=lf
 *.py   text eol=lf
 *.yml  text eol=lf
 *.yaml text eol=lf
@@ -6,10 +6,4 @@
 *.sh   text eol=lf
 *.bat  text eol=crlf
 *.ps1  text eol=crlf
-
-# Нормализуем к LF по умолчанию
-* text=auto eol=lf
-
-# Для Windows-скриптов сохраняем CRLF
-*.ps1 text eol=crlf
-*.bat text eol=crlf
+*.sql text eol=lf

--- a/db/migrations/0014_import_runs.sql
+++ b/db/migrations/0014_import_runs.sql
@@ -1,0 +1,219 @@
+-- db/migrations/0014_import_runs.sql
+-- ============================================================
+-- Import Runs: Attempt Journal with Retry Support
+-- ============================================================
+-- Version: 1.0 PRODUCTION (sanity-checked, ready for merge)
+-- Date: 2025-12-23
+-- Dependencies: Extends ingest_envelope system
+-- ============================================================
+
+-- NOTE: gen_random_uuid() requires pgcrypto extension in PostgreSQL.
+-- If pgcrypto is managed centrally, keep this comment only.
+-- Otherwise uncomment:
+-- CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- ============================================================
+-- Helper Function: Auto-update updated_at
+-- ============================================================
+
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at := NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION update_updated_at_column() IS
+    'Auto-updates updated_at column on row modification. Reusable trigger function.';
+
+-- ============================================================
+-- Main Table: import_runs
+-- ============================================================
+
+CREATE TABLE import_runs (
+    run_id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+    supplier VARCHAR(100) NOT NULL,
+    source_filename TEXT NOT NULL,
+    file_sha256 CHAR(64) NOT NULL,
+    file_size_bytes BIGINT,
+
+    envelope_id UUID NULL REFERENCES ingest_envelope(envelope_id) ON DELETE SET NULL,
+
+    as_of_date DATE NOT NULL,
+    as_of_datetime TIMESTAMPTZ,
+
+    status VARCHAR(20) NOT NULL
+        CHECK (status IN ('pending', 'running', 'success', 'failed', 'skipped', 'rolled_back'))
+        DEFAULT 'pending',
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    started_at TIMESTAMPTZ,
+    finished_at TIMESTAMPTZ,
+
+    triggered_by VARCHAR(100),
+    processing_mode VARCHAR(20) NOT NULL DEFAULT 'atomic'
+        CHECK (processing_mode IN ('atomic', 'chunked')),
+
+    total_rows_processed INT DEFAULT 0,
+    new_sku_count INT DEFAULT 0,
+    updated_sku_count INT DEFAULT 0,
+    new_winery_count INT DEFAULT 0,
+    quarantine_count INT DEFAULT 0,
+    rows_skipped INT DEFAULT 0,
+
+    error_summary TEXT,
+    error_details JSONB,
+
+    artifact_paths JSONB,
+    import_config JSONB
+);
+
+COMMENT ON TABLE import_runs IS
+    'Journal of import attempts. Supports retry after failed. Extends ingest_envelope.';
+
+COMMENT ON COLUMN import_runs.envelope_id IS
+    'Optional link to ingest_envelope. Set by PR-2 orchestrator for traceability.';
+
+COMMENT ON COLUMN import_runs.status IS
+    'pending=created, running=processing, success=done, failed=error, skipped=duplicate, rolled_back=manual fix.';
+
+-- ============================================================
+-- Triggers
+-- ============================================================
+
+CREATE TRIGGER trg_import_runs_updated_at
+    BEFORE UPDATE ON import_runs
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();
+
+-- ============================================================
+-- Constraints: Single Blocking Index
+-- ============================================================
+
+CREATE UNIQUE INDEX ux_import_runs_blocking_key
+    ON import_runs (supplier, file_sha256, as_of_date)
+    WHERE status IN ('pending', 'running', 'success');
+
+COMMENT ON INDEX ux_import_runs_blocking_key IS
+    'CRITICAL: Blocks concurrent imports, pending after success, duplicate success. Allows retry after failed, multiple skipped. NOTE: Stuck runs (pending/running) block new attempts until resolved (see operational notes).';
+
+-- ============================================================
+-- Performance Indexes
+-- ============================================================
+
+CREATE INDEX ix_import_runs_supplier_date
+    ON import_runs (supplier, as_of_date DESC, created_at DESC);
+
+CREATE INDEX ix_import_runs_status
+    ON import_runs (status, created_at DESC)
+    WHERE status IN ('running', 'pending', 'failed');
+
+CREATE INDEX ix_import_runs_success_recent
+    ON import_runs (supplier, finished_at DESC)
+    WHERE status = 'success';
+
+CREATE INDEX ix_import_runs_envelope_id
+    ON import_runs (envelope_id)
+    WHERE envelope_id IS NOT NULL;
+
+COMMENT ON INDEX ix_import_runs_envelope_id IS
+    'Supports joins to ingest_envelope for audit/traceability queries.';
+
+-- ============================================================
+-- Views
+-- ============================================================
+
+CREATE VIEW v_import_runs_summary AS
+SELECT
+    run_id,
+    supplier,
+    source_filename,
+    file_sha256,
+    as_of_date,
+    status,
+    started_at,
+    finished_at,
+    EXTRACT(EPOCH FROM (finished_at - started_at))::NUMERIC(10,2) AS duration_seconds,
+    total_rows_processed,
+    new_sku_count,
+    updated_sku_count,
+    quarantine_count,
+    error_summary,
+    triggered_by,
+    created_at
+FROM import_runs;
+
+COMMENT ON VIEW v_import_runs_summary IS
+    'Import runs with calculated duration. Caller must ORDER BY in query.';
+
+CREATE VIEW v_import_staleness AS
+SELECT
+    supplier,
+
+    MAX(finished_at) FILTER (WHERE status = 'success') AS last_success_at,
+    (MAX(finished_at) FILTER (WHERE status = 'success') IS NOT NULL) AS has_success,
+
+    EXTRACT(EPOCH FROM (
+        NOW() - MAX(finished_at) FILTER (WHERE status = 'success')
+    )) / 3600 AS hours_since_success,
+
+    COUNT(*) FILTER (
+        WHERE status = 'success'
+          AND finished_at > NOW() - INTERVAL '7 days'
+    ) AS success_count_7d,
+
+    COUNT(*) FILTER (
+        WHERE status = 'failed'
+          AND finished_at > NOW() - INTERVAL '7 days'
+    ) AS failed_count_7d,
+
+    COUNT(*) FILTER (WHERE status = 'running') AS currently_running,
+
+    (ARRAY_AGG(
+        error_summary
+        ORDER BY COALESCE(finished_at, created_at) DESC
+    ) FILTER (
+        WHERE status = 'failed'
+          AND COALESCE(finished_at, created_at) > NOW() - INTERVAL '7 days'
+    ))[1] AS last_error
+
+FROM import_runs
+GROUP BY supplier;
+
+COMMENT ON VIEW v_import_staleness IS
+    'Data freshness per supplier. Full history. COALESCE handles NULL finished_at. has_success simplifies alerts.';
+
+-- ============================================================
+-- Operational Notes: Handling Stuck Runs
+-- ============================================================
+--
+-- DETECTION (example threshold: 2 hours):
+--   SELECT run_id, supplier, status, started_at,
+--          EXTRACT(EPOCH FROM (NOW() - started_at))/60 AS minutes_running
+--   FROM import_runs
+--   WHERE status = 'running'
+--     AND started_at < NOW() - INTERVAL '2 hours';
+--
+-- RESOLUTION:
+--   UPDATE import_runs
+--   SET status = 'rolled_back',
+--       error_summary = 'Process crashed or timeout',
+--       finished_at = NOW()
+--   WHERE run_id = %s
+--     AND status IN ('pending', 'running');
+--
+-- AUTOMATION (PR-2/future):
+--   - periodic stale-run detector (e.g., every 15 minutes)
+--   - marks stale running/pending as rolled_back and notifies on-call
+--
+
+-- ============================================================
+-- Rollback Script
+-- ============================================================
+-- DROP VIEW IF EXISTS v_import_staleness CASCADE;
+-- DROP VIEW IF EXISTS v_import_runs_summary CASCADE;
+-- DROP TABLE IF EXISTS import_runs CASCADE;
+-- DROP FUNCTION IF EXISTS update_updated_at_column() CASCADE;

--- a/observability/grafana/dashboards/wine-assistant-api.json
+++ b/observability/grafana/dashboards/wine-assistant-api.json
@@ -1,53 +1,4 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_LOKI",
-      "label": "loki",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "loki",
-      "pluginName": "Loki"
-    }
-  ],
-  "__elements": {},
-  "__requires": [
-    {
-      "type": "panel",
-      "id": "barchart",
-      "name": "Bar chart",
-      "version": ""
-    },
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "10.4.2"
-    },
-    {
-      "type": "panel",
-      "id": "logs",
-      "name": "Logs",
-      "version": ""
-    },
-    {
-      "type": "datasource",
-      "id": "loki",
-      "name": "Loki",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "piechart",
-      "name": "Pie chart",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "timeseries",
-      "name": "Time series",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -74,7 +25,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "${DS_LOKI}"
+        "uid": "loki"
       },
       "fieldConfig": {
         "defaults": {
@@ -154,7 +105,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "${DS_LOKI}"
+            "uid": "loki"
           },
           "editorMode": "code",
           "expr": "sum(rate({job=\"docker-logs\"} |= \"http_request_completed\" [1m])) * 60",
@@ -168,7 +119,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "${DS_LOKI}"
+        "uid": "loki"
       },
       "fieldConfig": {
         "defaults": {
@@ -248,7 +199,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "${DS_LOKI}"
+            "uid": "loki"
           },
           "editorMode": "code",
           "expr": "avg(avg_over_time({job=\"docker-logs\"} |= \"http_request_completed\" | json | unwrap duration_ms [5m]))",
@@ -262,7 +213,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "${DS_LOKI}"
+        "uid": "loki"
       },
       "description": "",
       "fieldConfig": {
@@ -342,7 +293,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "${DS_LOKI}"
+            "uid": "loki"
           },
           "editorMode": "code",
           "expr": "sum by (status_code) (count_over_time({job=\"docker-logs\"} |= \"http_request_completed\" | json | status_code != \"\" [5m]))",
@@ -356,7 +307,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "${DS_LOKI}"
+        "uid": "loki"
       },
       "fieldConfig": {
         "defaults": {
@@ -404,7 +355,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "${DS_LOKI}"
+            "uid": "loki"
           },
           "editorMode": "code",
           "expr": "sum by (http_path) (count_over_time({job=\"docker-logs\"} |= \"http_request_completed\" | json | http_path != \"\" [1h]))",
@@ -418,7 +369,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "${DS_LOKI}"
+        "uid": "loki"
       },
       "fieldConfig": {
         "defaults": {
@@ -496,7 +447,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "${DS_LOKI}"
+            "uid": "loki"
           },
           "editorMode": "code",
           "expr": "avg by (http_path) (avg_over_time({job=\"docker-logs\"} |= \"http_request_completed\" | json | unwrap duration_ms [1h]))",
@@ -510,7 +461,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "${DS_LOKI}"
+        "uid": "loki"
       },
       "fieldConfig": {
         "defaults": {
@@ -558,7 +509,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "${DS_LOKI}"
+            "uid": "loki"
           },
           "editorMode": "code",
           "expr": "sum by (event) (count_over_time({job=\"docker-logs\"} |= \"api.app\" | json | level = \"ERROR\" [1h]))",
@@ -572,7 +523,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "${DS_LOKI}"
+        "uid": "loki"
       },
       "gridPos": {
         "h": 8,
@@ -595,7 +546,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "${DS_LOKI}"
+            "uid": "loki"
           },
           "editorMode": "code",
           "expr": "{job=\"docker-logs\"} |= \"http_request_completed\" | json",
@@ -609,7 +560,7 @@
     {
       "datasource": {
         "type": "loki",
-        "uid": "${DS_LOKI}"
+        "uid": "loki"
       },
       "description": "",
       "gridPos": {
@@ -633,7 +584,7 @@
         {
           "datasource": {
             "type": "loki",
-            "uid": "${DS_LOKI}"
+            "uid": "loki"
           },
           "editorMode": "code",
           "expr": "{job=\"docker-logs\", level=\"ERROR\"}",
@@ -645,7 +596,7 @@
       "type": "logs"
     }
   ],
-  "refresh": "15m",
+  "refresh": "5m",
   "schemaVersion": 39,
   "tags": [
     "wine-assistant",
@@ -663,6 +614,6 @@
   "timezone": "browser",
   "title": "Wine Assistant API Monitoring",
   "uid": "wine-assistant-api",
-  "version": 10,
+  "version": 22,
   "weekStart": ""
 }

--- a/project-structure.txt
+++ b/project-structure.txt
@@ -1,6 +1,6 @@
 # Wine Assistant — Project Structure
 
-Generated: 2025-12-21
+Generated: 2025-12-23
 
 This document is regenerated strictly from two inputs:
 1) `git ls-files` → `project-files.tracked.txt` (authoritative list of tracked files)
@@ -13,6 +13,7 @@ This document is regenerated strictly from two inputs:
 - `api/templates/ui.html`
 - `db/init.sql`
 - `db/migrate.sh`
+- `db/migrate.ps1`
 - `docker-compose.yml`
 - `docker-compose.observability.yml`
 - `docker-compose.storage.yml`
@@ -20,7 +21,7 @@ This document is regenerated strictly from two inputs:
 
 ## Tracked repository tree (from `git ls-files`, depth ≤ 5)
 
-Tracked files: 182
+Tracked files: 186
 
 ```
 .
@@ -75,22 +76,8 @@ Tracked files: 182
 │   └── migrate.sh
 ├── docs
 │   ├── dev
-│   │   ├── backup-dr-runbook.md
-│   │   ├── cheatsheet-from-clean-clone-to-green-tests.md
-│   │   ├── cleanup-test-data.md
-│   │   ├── dev-setup-windows.md
-│   │   ├── export-web-ui.md
-│   │   ├── gitignore.md
-│   │   ├── how-to-create-analysis-bundle.md
-│   │   ├── issue-83-84-notes.md
-│   │   ├── issue-85-partitioning-notes.md
-│   │   ├── issue-91-summary.md
-│   │   ├── logging-eventsdd05122025.md
-│   │   ├── manual-smoke-checkdd03122025.md
-│   │   ├── PR_body_ru_extended_wineries_sku_20251130dd30112025.md
 │   │   ├── PR_DESCRIPTION.md
-│   │   ├── pricing-rules.md
-│   │   ├── producer_site_image_url_readme_ru.md
+│   │   ├── PR_body_ru_extended_wineries_sku_20251130dd30112025.md
 │   │   ├── README-before06112025.md
 │   │   ├── README-before07112025-01.md
 │   │   ├── README-before07112025.md
@@ -103,31 +90,46 @@ Tracked files: 182
 │   │   ├── README-before19112025.md
 │   │   ├── README-before21112025.md
 │   │   ├── README-before22112025.md
+│   │   ├── README-before22122025.md
 │   │   ├── README-before24112025.md
 │   │   ├── README-before28112025.md
 │   │   ├── README-before30112025.md
-│   │   ├── readme-inventory-and-chartsdd03122025.md
 │   │   ├── README.auto_images.ru-28112025.md
 │   │   ├── README.auto_images.ru.extended-28112025.md
 │   │   ├── README.extradd04122025.md
 │   │   ├── README.ru-additiondd28112025.md
 │   │   ├── README.wineriesdd30112025.md
+│   │   ├── READMEdd04122025.md
+│   │   ├── backup-dr-runbook.md
+│   │   ├── cheatsheet-from-clean-clone-to-green-tests.md
+│   │   ├── cleanup-test-data.md
+│   │   ├── dev-setup-windows.md
+│   │   ├── export-web-ui.md
+│   │   ├── gitignore.md
+│   │   ├── how-to-create-analysis-bundle.md
+│   │   ├── issue-83-84-notes.md
+│   │   ├── issue-85-partitioning-notes.md
+│   │   ├── issue-91-summary.md
+│   │   ├── logging-eventsdd05122025.md
+│   │   ├── manual-smoke-checkdd03122025.md
+│   │   ├── pricing-rules.md
+│   │   ├── producer_site_image_url_readme_ru.md
+│   │   ├── readme-inventory-and-chartsdd03122025.md
 │   │   ├── readme_block_new_products_fields_ru.md
 │   │   ├── readme_wine_fields_export.md
-│   │   ├── READMEdd04122025.md
 │   │   ├── release-notes-2025-12-16.md
 │   │   ├── release-notes-2025-12-21.md
 │   │   ├── web-ui.md
 │   │   └── windows-powershell-http.md
 │   ├── BEFORE_AFTER_COMPARISON.md
+│   ├── README_UPDATE_SUMMARY.md
+│   ├── ROADMAP_v3_RU.md
 │   ├── dev-checklist.ps1
 │   ├── manual-smoke-check.md
 │   ├── pr-93-summary.md
-│   ├── README_UPDATE_SUMMARY.md
 │   ├── requirements.md
 │   ├── roadmap_sprint7+.md
-│   ├── roadmap_sprint7+_v2.md
-│   └── ROADMAP_v3_RU.md
+│   └── roadmap_sprint7+_v2.md
 ├── etl
 │   ├── image_extractor.py
 │   ├── mapping_template.json
@@ -139,19 +141,20 @@ Tracked files: 182
 ├── observability
 │   ├── grafana
 │   │   ├── dashboards
-│   │   │   └── wine-assistant-api.json
+│   │   │   ├── wine-assistant-api.json
+│   │   │   └── wine-assistant-backup-dr.json
 │   │   └── provisioning
 │   │       ├── dashboards
 │   │       │   └── dashboards.yml
 │   │       └── datasources
 │   │           └── datasources.yml
+│   ├── README.md
 │   ├── loki-config.yml
-│   ├── promtail-config.yml
-│   └── README.md
+│   └── promtail-config.yml
 ├── ops
 │   └── backup
-│       ├── backup.sh
-│       └── Dockerfile
+│       ├── Dockerfile
+│       └── backup.sh
 ├── scripts
 │   ├── __init__.py
 │   ├── backfill_current_prices.py
@@ -162,6 +165,7 @@ Tracked files: 182
 │   ├── data_quality.py
 │   ├── date_extraction.py
 │   ├── dr_smoke.ps1
+│   ├── emit_event.py
 │   ├── enrich_producers.py
 │   ├── extract_wineries_from_pdf.py
 │   ├── idempotency.py
@@ -174,6 +178,7 @@ Tracked files: 182
 │   ├── migrate.ps1
 │   ├── minio_backups.py
 │   ├── normalize_wineries_suppliers.py
+│   ├── prune_local_backups.py
 │   ├── quick_smoke_check.ps1
 │   ├── run_integration_tests.ps1
 │   ├── setup_scheduler.ps1
@@ -204,10 +209,10 @@ Tracked files: 182
 │   │   ├── test_load_utils.py
 │   │   ├── test_schemas.py
 │   │   └── test_validation.py
+│   ├── README.md
 │   ├── __init__.py
 │   ├── conftest.py
 │   ├── cors-test.html
-│   ├── README.md
 │   ├── test_api_health.py
 │   ├── test_api_limits_and_security.py
 │   ├── test_api_products_happy.py
@@ -221,18 +226,18 @@ Tracked files: 182
 ├── .gitleaks.toml
 ├── .pre-commit-config.yaml
 ├── CHANGELOG.md
-├── docker-compose.observability.yml
-├── docker-compose.storage.yml
-├── docker-compose.yml
 ├── Dockerfile
 ├── INDEX.md
 ├── Makefile
-├── project-structure.txt
 ├── PROTECTION_CHECK.txt
-├── pyproject.toml
-├── pytest.ini
 ├── QUICK_REFERENCE.md
 ├── README.md
+├── docker-compose.observability.yml
+├── docker-compose.storage.yml
+├── docker-compose.yml
+├── project-structure.txt
+├── pyproject.toml
+├── pytest.ini
 └── requirements.txt
 ```
 
@@ -242,25 +247,27 @@ Tracked files: 182
 
 Untracked directories at root (subdirs/files counts derived from `tree /F /A`):
 
-| Dir             | Subdirs | Files |
-| --------------- | ------- | ----- |
-| .idea           | 2       | 8     |
-| .pytest_cache   | 3       | 5     |
-| .ruff_cache     | 3       | 14    |
-| .venv           | 1959    | 16094 |
-| _bundles        | 1       | 1     |
-| backups         | 1       | 5     |
-| htmlcov         | 1       | 33    |
-| logs            | 1       | 0     |
-| restore_tmp     | 1       | 1     |
-| smoke_artifacts | 1       | 3     |
-| static          | 2       | 296   |
+| Dir | Subdirs | Files |
+| --- | ------- | ----- |
+| .idea | 1 | 8 |
+| .pytest_cache | 2 | 5 |
+| .ruff_cache | 2 | 14 |
+| .venv | 1958 | 16094 |
+| _bundles | 0 | 2 |
+| backups | 0 | 6 |
+| htmlcov | 0 | 33 |
+| logs | 1 | 18 |
+| restore_tmp | 0 | 1 |
+| smoke_artifacts | 0 | 3 |
+| static | 1 | 296 |
 
 Untracked files at root:
 
 - `.coverage`
 - `.env`
 - `.env.backup`
+- `Makefile-backup`
+- `docker-compose.observability.yml.backup`
 - `ls_api.txt`
 - `ls_api_templates.txt`
 - `ls_db.txt`
@@ -275,11 +282,11 @@ Untracked files at root:
 - `ls_scripts.txt`
 - `ls_static.txt`
 - `ls_tests.txt`
-- `Makefile-backup`
 - `must-have-check.txt`
 - `project-files.tracked.txt`
 - `project-structure-auto.txt`
 - `structure_dump.zip`
+- `wine-assistant_analysis_bundle_20251221_224949.zip`
 
 ### Untracked items inside tracked directories (observed)
 
@@ -290,9 +297,9 @@ Untracked files at root:
   - Backups: `etl/image_extractor.py.backup`, `etl/image_extractor.py.backup1`
   - Python bytecode cache: `etl/__pycache__/*.pyc` (1 file)
 - `scripts/`
-  - Backups: `scripts/load_utils.py.backup`, `scripts/load_utils.py.backup1`
+  - Backups: `scripts/dr_smoke.ps1.backup`, `scripts/load_utils.py.backup`, `scripts/load_utils.py.backup1`, `scripts/minio_backups.py.backup`
   - Local variants: `scripts/manual_smoke_check.fixed.v4.ps1`, `scripts/quick_smoke_check.fixed.v4.ps1`
-  - Python bytecode cache: `scripts/__pycache__/*.pyc` (13 files)
+  - Python bytecode cache: `scripts/__pycache__/*.pyc` (15 files)
 - `tests/`
   - Python bytecode cache: `tests/**/__pycache__/*.pyc` (26 files)
 - `docs/`
@@ -300,41 +307,49 @@ Untracked files at root:
 - `data/`
   - `data/catalog/*` (5 files; includes multiple `wineries_enrichment*.xlsx` and one PDF)
   - `data/inbox/*` (18 files; `.xlsx` price lists; filenames include Cyrillic characters)
+- `observability/`
+  - `observability/promtail-config.yml.backup`
 
 ### Selected contents of notable untracked root directories (examples)
 
-- `backups/` (5 files)
-  - `backups/db_20251213_215134.sql`
-  - `backups/pgdata_20251213_215415.tgz`
-  - `backups/static_images_20251213_215631.zip`
-  - `backups/wine_db_20251221_184225.dump`
-  - `backups/wine_db_20251221_184326.dump`
+- `backups/` (6 files)
+  - backups/db_20251213_215134.sql
+  - backups/pgdata_20251213_215415.tgz
+  - backups/static_images_20251213_215631.zip
+  - backups/wine_db_20251222_140049_172449_16544.dump
+  - backups/wine_db_20251222_142605_333267_15472.dump
+  - backups/wine_db_20251222_225916_208294_12384.dump
 - `restore_tmp/` (1 file)
-  - `restore_tmp/remote_latest.dump`
+  - restore_tmp/remote_latest.dump
 - `smoke_artifacts/` (3 files)
-  - `smoke_artifacts/inventory_history_D010210.xlsx`
-  - `smoke_artifacts/price_history_D010210.xlsx`
-  - `smoke_artifacts/sku_D010210.pdf`
-- `_bundles/` (1 file)
-  - `_bundles/wine-assistant_analysis_bundle_20251221_030310.zip`
+  - smoke_artifacts/inventory_history_D010210.xlsx
+  - smoke_artifacts/price_history_D010210.xlsx
+  - smoke_artifacts/sku_D010210.pdf
+- `_bundles/` (2 files)
+  - _bundles/wine-assistant_analysis_bundle_20251221_030310.zip
+  - _bundles/wine-assistant_analysis_bundle_20251221_225622.zip
 - `static/` (296 files; primarily images under `static/images/`)
-  - Examples: `static/images/D000081.jpeg`, `static/images/D011535.png`
+  - Examples:
+  - static/images/Alsace___������.png
+  - static/images/D000081.jpeg
+  - static/images/Red_wine___�������_����.png
+  - static/images/Rose_wine___�������_����.png
 
 ## Must-have check (from `must-have-check.txt`)
 
-| Path                             | Exists |
-| -------------------------------- | ------ |
-| README.md                        | True   |
-| CHANGELOG.md                     | True   |
-| Dockerfile                       | True   |
-| docker-compose.yml               | True   |
-| docker-compose.observability.yml | True   |
-| requirements.txt                 | True   |
-| Makefile                         | True   |
-| project-structure.txt            | True   |
-| db/migrate.sh                    | True   |
-| db/init.sql                      | True   |
-| api/app.py                       | True   |
-| api/export.py                    | True   |
-| api/wsgi.py                      | True   |
-| api/templates/ui.html            | True   |
+| Path | Exists |
+| ---- | ------ |
+| README.md | True |
+| CHANGELOG.md | True |
+| Dockerfile | True |
+| docker-compose.yml | True |
+| docker-compose.observability.yml | True |
+| requirements.txt | True |
+| Makefile | True |
+| project-structure.txt | True |
+| db/migrate.sh | True |
+| db/init.sql | True |
+| api/app.py | True |
+| api/export.py | True |
+| api/wsgi.py | True |
+| api/templates/ui.html | True |

--- a/pytest.ini
+++ b/pytest.ini
@@ -28,6 +28,7 @@ markers =
     smoke: Critical smoke tests
     requires_real_data: tests that rely on preloaded real price list data
     monitoring: tests that validate real SKUs / production-like data consistency
+    db: tests requiring a running PostgreSQL (enable with RUN_DB_TESTS=1)
 
 # Minimum Python version
 minversion = 3.11

--- a/scripts/import_run_registry.py
+++ b/scripts/import_run_registry.py
@@ -1,0 +1,343 @@
+"""
+Import Run Registry (v1.0 PRODUCTION)
+====================================
+
+Purpose:
+- Journal of import attempts (import_runs) with retry support.
+- Extends ingest_envelope (optional envelope_id link).
+- Reuses scripts.idempotency.compute_file_sha256() (no duplication).
+
+CRITICAL: Transaction Separation Contract (R0.2)
+-----------------------------------------------
+Registry writes MUST be committed separately from the import data transaction.
+
+Typical pattern:
+1) action = check_attempt_or_get_blocker()  # read-only
+2) run_id = create_attempt(); conn.commit()
+3) mark_running(run_id); conn.commit()
+4) run import transaction (with conn/cur); commit/rollback
+5) mark_success/mark_failed; conn.commit()
+
+IntegrityError handling:
+- After psycopg2.IntegrityError, connection is aborted.
+  Caller MUST call conn.rollback() before any further operations.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from datetime import date, datetime
+from typing import Any, Dict, Literal, Optional, Tuple
+from uuid import UUID
+
+import psycopg2
+from psycopg2.extras import Json, RealDictCursor
+
+from scripts.idempotency import compute_file_sha256
+
+logger = logging.getLogger(__name__)
+
+ImportStatus = Literal["pending", "running", "success", "failed", "skipped", "rolled_back"]
+ProcessingMode = Literal["atomic", "chunked"]
+AttemptAction = Literal["START", "SKIP_ALREADY_SUCCESS", "SKIP_ALREADY_RUNNING", "RETRY_AFTER_FAILED"]
+
+
+@dataclass(frozen=True)
+class Blocker:
+    run_id: UUID
+    status: ImportStatus
+    error_summary: Optional[str]
+    created_at: datetime
+    started_at: Optional[datetime]
+
+
+class ImportRunRegistry:
+    def __init__(self, connection: psycopg2.extensions.connection, processing_mode: ProcessingMode = "atomic"):
+        self.conn = connection
+        self.processing_mode = processing_mode
+
+    def check_attempt_or_get_blocker(
+        self,
+        supplier: str,
+        file_path: str,
+        as_of_date: date,
+    ) -> Tuple[AttemptAction, Optional[UUID], Optional[Dict[str, Any]]]:
+        """
+        Priority:
+        1) blocker: success/pending/running
+        2) failed/rolled_back => retry allowed
+        3) none => START
+        """
+        file_sha256 = compute_file_sha256(file_path)
+
+        with self.conn.cursor(cursor_factory=RealDictCursor) as cur:
+            # 1) blocker first
+            cur.execute(
+                """
+                SELECT run_id, status, error_summary, created_at, started_at
+                FROM import_runs
+                WHERE supplier = %s
+                  AND file_sha256 = %s
+                  AND as_of_date = %s
+                  AND status IN ('success','pending','running')
+                ORDER BY created_at DESC
+                LIMIT 1
+                """,
+                (supplier, file_sha256, as_of_date),
+            )
+            blocker = cur.fetchone()
+            if blocker:
+                if blocker["status"] == "success":
+                    return "SKIP_ALREADY_SUCCESS", None, dict(blocker)
+                return "SKIP_ALREADY_RUNNING", None, dict(blocker)
+
+            # 2) last failed/rolled_back
+            cur.execute(
+                """
+                SELECT run_id, status, error_summary, created_at, started_at
+                FROM import_runs
+                WHERE supplier = %s
+                  AND file_sha256 = %s
+                  AND as_of_date = %s
+                  AND status IN ('failed','rolled_back')
+                ORDER BY created_at DESC
+                LIMIT 1
+                """,
+                (supplier, file_sha256, as_of_date),
+            )
+            failed = cur.fetchone()
+            if failed:
+                return "RETRY_AFTER_FAILED", None, dict(failed)
+
+            return "START", None, None
+
+    def create_attempt(
+        self,
+        supplier: str,
+        file_path: str,
+        as_of_date: date,
+        triggered_by: str,
+        as_of_datetime: Optional[datetime] = None,
+        envelope_id: Optional[UUID] = None,
+        import_config: Optional[Dict[str, Any]] = None,
+    ) -> UUID:
+        """
+        Creates a new 'pending' attempt.
+        NOTE: caller must commit.
+        Raises psycopg2.IntegrityError if blocking attempt exists.
+        """
+        file_sha256 = compute_file_sha256(file_path)
+        file_size = os.path.getsize(file_path)
+        source_filename = os.path.basename(file_path)
+
+        with self.conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO import_runs (
+                    supplier, source_filename, file_sha256, file_size_bytes,
+                    envelope_id,
+                    as_of_date, as_of_datetime,
+                    status,
+                    triggered_by, processing_mode,
+                    import_config
+                )
+                VALUES (%s,%s,%s,%s,%s,%s,%s,'pending',%s,%s,%s)
+                RETURNING run_id
+                """,
+                (
+                    supplier,
+                    source_filename,
+                    file_sha256,
+                    file_size,
+                    envelope_id,
+                    as_of_date,
+                    as_of_datetime,
+                    triggered_by,
+                    self.processing_mode,
+                    Json(import_config) if import_config else None,
+                ),
+            )
+            run_id = cur.fetchone()[0]
+            logger.info("Created import attempt %s for %s/%s", run_id, supplier, source_filename)
+            return run_id
+
+    def create_skipped_attempt(
+        self,
+        supplier: str,
+        file_path: str,
+        as_of_date: date,
+        reason: str,
+        triggered_by: str,
+        envelope_id: Optional[UUID] = None,
+    ) -> UUID:
+        """
+        Creates an audit row with status='skipped' (does not block future attempts).
+        NOTE: caller must commit.
+        """
+        file_sha256 = compute_file_sha256(file_path)
+        source_filename = os.path.basename(file_path)
+
+        with self.conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO import_runs (
+                    supplier, source_filename, file_sha256,
+                    envelope_id,
+                    as_of_date,
+                    status,
+                    error_summary,
+                    triggered_by,
+                    finished_at
+                )
+                VALUES (%s,%s,%s,%s,%s,'skipped',%s,%s,NOW())
+                RETURNING run_id
+                """,
+                (supplier, source_filename, file_sha256, envelope_id, as_of_date, reason, triggered_by),
+            )
+            run_id = cur.fetchone()[0]
+            logger.info("Created skipped attempt %s (%s)", run_id, reason)
+            return run_id
+
+    def mark_running(self, run_id: UUID) -> None:
+        """NOTE: caller must commit."""
+        with self.conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE import_runs
+                SET status = 'running',
+                    started_at = NOW()
+                WHERE run_id = %s
+                  AND status = 'pending'
+                """,
+                (run_id,),
+            )
+            if cur.rowcount == 0:
+                raise ValueError(f"Cannot mark running: {run_id} (expected status 'pending')")
+            logger.info("Marked run %s as running", run_id)
+
+    def mark_success(
+        self,
+        run_id: UUID,
+        metrics: Optional[Dict[str, int]] = None,
+        artifact_paths: Optional[Dict[str, str]] = None,
+        envelope_id: Optional[UUID] = None,
+    ) -> None:
+        """NOTE: caller must commit."""
+        set_parts = ["status = 'success'", "finished_at = NOW()"]
+        params: list[Any] = []
+
+        if metrics:
+            for k, v in metrics.items():
+                set_parts.append(f"{k} = %s")
+                params.append(v)
+
+        if artifact_paths:
+            set_parts.append("artifact_paths = %s")
+            params.append(Json(artifact_paths))
+
+        if envelope_id:
+            set_parts.append("envelope_id = %s")
+            params.append(envelope_id)
+
+        params.append(run_id)
+
+        with self.conn.cursor() as cur:
+            cur.execute(
+                f"""
+                UPDATE import_runs
+                SET {", ".join(set_parts)}
+                WHERE run_id = %s
+                  AND status = 'running'
+                """,
+                params,
+            )
+            if cur.rowcount == 0:
+                raise ValueError(f"Cannot mark success: {run_id} (expected status 'running')")
+            logger.info("Marked run %s as success", run_id)
+
+    def mark_failed(
+        self,
+        run_id: UUID,
+        error_summary: str,
+        error_details: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """NOTE: caller must commit."""
+        with self.conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE import_runs
+                SET status = 'failed',
+                    finished_at = NOW(),
+                    error_summary = %s,
+                    error_details = %s
+                WHERE run_id = %s
+                  AND status = 'running'
+                """,
+                (error_summary, Json(error_details) if error_details else None, run_id),
+            )
+            if cur.rowcount == 0:
+                raise ValueError(f"Cannot mark failed: {run_id} (expected status 'running')")
+            logger.info("Marked run %s as failed: %s", run_id, error_summary)
+
+    def get_run_status(self, run_id: UUID) -> Dict[str, Any]:
+        with self.conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(
+                """
+                SELECT *,
+                       EXTRACT(EPOCH FROM (finished_at - started_at))::NUMERIC(10,2) AS duration_seconds
+                FROM import_runs
+                WHERE run_id = %s
+                """,
+                (run_id,),
+            )
+            row = cur.fetchone()
+            if not row:
+                raise ValueError(f"Run not found: {run_id}")
+            return dict(row)
+
+    def get_staleness(self, supplier: str) -> Optional[Dict[str, Any]]:
+        with self.conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(
+                """
+                SELECT *
+                FROM v_import_staleness
+                WHERE supplier = %s
+                """,
+                (supplier,),
+            )
+            row = cur.fetchone()
+            return dict(row) if row else None
+
+    def list_recent(
+        self,
+        limit: int = 20,
+        supplier: Optional[str] = None,
+        status: Optional[ImportStatus] = None,
+    ) -> list[Dict[str, Any]]:
+        where_parts = []
+        params: list[Any] = []
+
+        if supplier:
+            where_parts.append("supplier = %s")
+            params.append(supplier)
+        if status:
+            where_parts.append("status = %s")
+            params.append(status)
+
+        where_sql = ("WHERE " + " AND ".join(where_parts)) if where_parts else ""
+        params.append(limit)
+
+        with self.conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(
+                f"""
+                SELECT *
+                FROM v_import_runs_summary
+                {where_sql}
+                ORDER BY created_at DESC
+                LIMIT %s
+                """,
+                params,
+            )
+            return [dict(r) for r in cur.fetchall()]

--- a/tests/unit/test_import_run_registry.py
+++ b/tests/unit/test_import_run_registry.py
@@ -1,0 +1,237 @@
+import os
+from datetime import date
+
+import psycopg2
+import pytest
+
+from scripts.idempotency import compute_file_sha256
+from scripts.import_run_registry import ImportRunRegistry
+
+pytestmark = pytest.mark.db
+
+
+@pytest.fixture(autouse=True)
+def _clean_import_runs(db_connection):
+    # ВАЖНО: тесты делают COMMIT, поэтому чистим явно
+    with db_connection.cursor() as cur:
+        cur.execute("TRUNCATE TABLE import_runs CASCADE")
+    db_connection.commit()
+
+
+@pytest.fixture
+def sample_file(tmp_path):
+    p = tmp_path / "supplier1_20251223.xlsx"
+    p.write_text("Sample data")
+    return str(p)
+
+
+def test_success_blocks_new_pending(db_connection, sample_file):
+    registry = ImportRunRegistry(db_connection)
+
+    run_id = registry.create_attempt(
+        supplier="supplier1",
+        file_path=sample_file,
+        as_of_date=date(2025, 12, 23),
+        triggered_by="test",
+    )
+    db_connection.commit()
+
+    registry.mark_running(run_id)
+    db_connection.commit()
+
+    registry.mark_success(run_id)
+    db_connection.commit()
+
+    with pytest.raises(psycopg2.IntegrityError) as exc:
+        registry.create_attempt(
+            supplier="supplier1",
+            file_path=sample_file,
+            as_of_date=date(2025, 12, 23),
+            triggered_by="test2",
+        )
+        db_connection.commit()
+
+    assert "ux_import_runs_blocking_key" in str(exc.value)
+    db_connection.rollback()  # critical: recover connection
+
+
+def test_failed_allows_retry(db_connection, sample_file):
+    registry = ImportRunRegistry(db_connection)
+
+    run_id = registry.create_attempt(
+        supplier="supplier1",
+        file_path=sample_file,
+        as_of_date=date(2025, 12, 23),
+        triggered_by="test",
+    )
+    db_connection.commit()
+
+    registry.mark_running(run_id)
+    db_connection.commit()
+
+    registry.mark_failed(run_id, "Test error")
+    db_connection.commit()
+
+    run_id2 = registry.create_attempt(
+        supplier="supplier1",
+        file_path=sample_file,
+        as_of_date=date(2025, 12, 23),
+        triggered_by="retry",
+    )
+    db_connection.commit()
+
+    assert run_id2 != run_id
+
+
+def test_blocker_first_with_anomaly(db_connection, sample_file):
+    registry = ImportRunRegistry(db_connection)
+
+    run_id1 = registry.create_attempt(
+        supplier="supplier1",
+        file_path=sample_file,
+        as_of_date=date(2025, 12, 23),
+        triggered_by="test1",
+    )
+    db_connection.commit()
+    registry.mark_running(run_id1)
+    db_connection.commit()
+    registry.mark_success(run_id1)
+    db_connection.commit()
+
+    sha = compute_file_sha256(sample_file)
+    with db_connection.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO import_runs (
+                supplier, source_filename, file_sha256, as_of_date,
+                status, error_summary, triggered_by
+            )
+            VALUES (%s,%s,%s,%s,'failed','Anomaly','direct_sql')
+            """,
+            ("supplier1", os.path.basename(sample_file), sha, date(2025, 12, 23)),
+        )
+    db_connection.commit()
+
+    action, _, blocker = registry.check_attempt_or_get_blocker(
+        supplier="supplier1",
+        file_path=sample_file,
+        as_of_date=date(2025, 12, 23),
+    )
+    assert action == "SKIP_ALREADY_SUCCESS"
+    assert str(blocker["run_id"]) == str(run_id1)
+
+
+def test_running_blocks_concurrent(db_connection, sample_file):
+    registry = ImportRunRegistry(db_connection)
+
+    run_id = registry.create_attempt(
+        supplier="supplier1",
+        file_path=sample_file,
+        as_of_date=date(2025, 12, 23),
+        triggered_by="test",
+    )
+    db_connection.commit()
+    registry.mark_running(run_id)
+    db_connection.commit()
+
+    action, _, blocker = registry.check_attempt_or_get_blocker(
+        supplier="supplier1",
+        file_path=sample_file,
+        as_of_date=date(2025, 12, 23),
+    )
+    assert action == "SKIP_ALREADY_RUNNING"
+    assert str(blocker["run_id"]) == str(run_id)
+
+
+def test_skipped_does_not_block(db_connection, sample_file):
+    registry = ImportRunRegistry(db_connection)
+
+    skip_id = registry.create_skipped_attempt(
+        supplier="supplier1",
+        file_path=sample_file,
+        as_of_date=date(2025, 12, 23),
+        reason="Test skip",
+        triggered_by="test",
+    )
+    db_connection.commit()
+
+    run_id = registry.create_attempt(
+        supplier="supplier1",
+        file_path=sample_file,
+        as_of_date=date(2025, 12, 23),
+        triggered_by="test2",
+    )
+    db_connection.commit()
+
+    assert run_id != skip_id
+
+
+def test_registry_survives_import_rollback(db_connection, sample_file):
+    registry = ImportRunRegistry(db_connection)
+
+    run_id = registry.create_attempt(
+        supplier="supplier1",
+        file_path=sample_file,
+        as_of_date=date(2025, 12, 23),
+        triggered_by="test",
+    )
+    db_connection.commit()
+
+    registry.mark_running(run_id)
+    db_connection.commit()
+
+    try:
+        with db_connection:
+            with db_connection.cursor() as cur:
+                cur.execute("SELECT 1")
+            raise RuntimeError("Simulated import failure")
+    except RuntimeError:
+        pass
+
+    registry.mark_failed(run_id, "Import failed")
+    db_connection.commit()
+
+    status = registry.get_run_status(run_id)
+    assert status["status"] == "failed"
+    assert status["error_summary"] == "Import failed"
+
+
+def test_v_import_staleness_has_success_and_last_error_coalesce(db_connection, sample_file):
+    registry = ImportRunRegistry(db_connection)
+
+    sha = compute_file_sha256(sample_file)
+    with db_connection.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO import_runs (
+                supplier, source_filename, file_sha256, as_of_date,
+                status, error_summary, triggered_by,
+                started_at, finished_at
+            )
+            VALUES (%s,%s,%s,%s,'failed','Failed-without-finished','direct_sql', NOW(), NULL)
+            """,
+            ("supplier1", os.path.basename(sample_file), sha, date(2025, 12, 23)),
+        )
+    db_connection.commit()
+
+    st = registry.get_staleness("supplier1")
+    assert st is not None
+    assert st["has_success"] is False
+    assert st["last_error"] == "Failed-without-finished"
+
+    run_id = registry.create_attempt(
+        supplier="supplier1",
+        file_path=sample_file,
+        as_of_date=date(2025, 12, 23),
+        triggered_by="test",
+    )
+    db_connection.commit()
+    registry.mark_running(run_id)
+    db_connection.commit()
+    registry.mark_success(run_id)
+    db_connection.commit()
+
+    st2 = registry.get_staleness("supplier1")
+    assert st2 is not None
+    assert st2["has_success"] is True
+    assert st2["last_success_at"] is not None


### PR DESCRIPTION
## Что сделано

Добавлен реестр попыток импорта (Import Run Registry), чтобы:
- журналировать каждую попытку импорта,
- блокировать параллельные/дублирующие импорты одного и того же файла/даты,
- разрешать retry после failed,
- иметь основу для мониторинга свежести импорта и алертов.

## Изменения по файлам

- `db/migrations/0014_import_runs.sql`
  - Таблица `import_runs` (pending/running/success/failed/skipped/rolled_back)
  - Уникальный частичный индекс-блокировка `ux_import_runs_blocking_key`
    - блокирует повтор/параллель: status in (pending, running, success)
    - допускает retry после failed/rolled_back
  - Представления:
    - `v_import_runs_summary`
    - `v_import_staleness` (last_success_at, hours_since_success, last_error и т.п.)
  - Trigger `updated_at` через `update_updated_at_column()`

- `scripts/import_run_registry.py`
  - Класс `ImportRunRegistry`:
    - `check_attempt_or_get_blocker()` (START / SKIP_ALREADY_SUCCESS / SKIP_ALREADY_RUNNING / RETRY_AFTER_FAILED)
    - `create_attempt()`, `create_skipped_attempt()`
    - `mark_running()`, `mark_success()`, `mark_failed()`
    - `get_run_status()`, `get_staleness()`, `list_recent()`
  - Контракт: registry commit отдельно от транзакции импорта (разделение транзакций)

- `tests/unit/test_import_run_registry.py`
  - Набор DB-тестов (маркер `db`), проверяющих блокировку success/running, retry после failed, skipped не блокирует и т.д.

- `pytest.ini` + `tests/conftest.py`
  - Маркер `db`, запуск DB-тестов только при `RUN_DB_TESTS=1`
  - Если Postgres недоступен — тесты пропускаются с понятным сообщением

- `.gitattributes`
  - Нормализация EOL: по умолчанию LF, для `.ps1/.bat` CRLF, для `.sql` LF

- `observability/grafana/dashboards/wine-assistant-api.json`
  - Datasource uid зафиксирован на `loki` (без переменной `${DS_LOKI}`)
  - refresh 5m

## Как тестировалось

- `pytest -q` (без DB) — PASS
- `RUN_DB_TESTS=1 pytest -q tests/unit/test_import_run_registry.py` — PASS
- `ruff check .` — PASS

## Примечания

- `gen_random_uuid()` требует `pgcrypto` (или эквивалентную подготовку). В миграции оставлен комментарий; расширение включается согласно принятому способу управления расширениями в проекте.
