### PR TITLE
chore(ops): print one-line command in verbose mode for wrappers

### DIFF
--- a/QUICK_REFERENCE.md
+++ b/QUICK_REFERENCE.md
@@ -46,9 +46,35 @@ Wrapper скрипт автоматически:
   -AsOfDate "2025-12-06"
 ```
 
-**Диагностика файлов:**
-- `-Verbose` — показывает топ-5 кандидатов с датами из имени и LastWriteTime
-- `-WhatIf` — не запускает импорт, только показывает выбранный файл и as_of_date
+**Диагностика файлов (пример вывода `-Verbose -WhatIf`):**
+```
+=== Wine Assistant - Daily Import ===
+Repo root:       D:\...\wine-assistant
+Supplier:        dreemwine
+
+PowerShell: 5.1.26100.7462
+Python: D:\...\wine-assistant\.venv\Scripts\python.exe
+Mode:            auto-discovery
+Inbox:           D:\...\wine-assistant\data\inbox
+
+Scanning inbox: D:\...\wine-assistant\data\inbox
+Top candidates (sorted):
+ 1) 2025_12_10 Прайс_Легенда_Виноделия.xlsx | parsed_date=2025-12-10 | last_write=2025-12-24 13:42:00
+ 2) 2025_12_03 Прайс_Легенда_Виноделия.xlsx | parsed_date=2025-12-03 | last_write=2025-12-03 11:00:00
+ 3) 2025_12_02 Прайс_Легенда_Виноделия.xlsx | parsed_date=2025-12-02 | last_write=2025-12-24 13:42:00
+Chosen file: D:\...\2025_12_10 Прайс_Легенда_Виноделия.xlsx
+Selected file:   2025_12_10 Прайс_Легенда_Виноделия.xlsx
+Selected full path: D:\...\2025_12_10 Прайс_Легенда_Виноделия.xlsx
+as_of_date:      2025-12-10 (from filename)
+as_of_date source: filename (override via -AsOfDate to change)
+Command:        "D:\...\.venv\Scripts\python.exe" -m scripts.run_import_orchestrator --supplier dreemwine --file "..." --as-of-date 2025-12-10 --import-fn scripts.import_targets.run_daily_adapter:import_with_run_daily
+
+WHATIF: import orchestrator will NOT be executed.
+WHATIF: command       = "..." -m scripts.run_import_orchestrator ...
+WHATIF: supplier      = dreemwine
+WHATIF: selected file = D:\...\2025_12_10 Прайс_Легенда_Виноделия.xlsx
+WHATIF: as_of_date    = 2025-12-10
+```
 
 ### Ручной запуск orchestrator
 
@@ -137,11 +163,7 @@ python -m scripts.run_import_orchestrator ...
 # Диагностика: проверить какой файл будет выбран
 .\scripts\run_daily_import.ps1 -Supplier "dreemwine" -Verbose -WhatIf
 
-# Output покажет:
-# VERBOSE: Top candidates (sorted):
-# VERBOSE:  1) 2025_12_10 Прайс... | parsed_date=2025-12-10 | last_write=...
-# WHATIF: selected file = ...
-# WHATIF: as_of_date     = 2025-12-10
+# Output покажет топ-5 кандидатов и выбранный файл (см. пример выше)
 
 # Решение: явно указать файл
 .\scripts\run_daily_import.ps1 -Supplier "dreemwine" -FilePath "data/inbox/specific_file.xlsx"
@@ -188,24 +210,48 @@ Get-ChildItem "data/inbox/*.xlsx" |
 ```powershell
 # Dry-run: проверить параметры и команду без запуска
 .\scripts\run_stale_detector.ps1 -RunningMinutes 120 -PendingMinutes 15 -Verbose -WhatIf
+```
 
-# Expected output:
-# VERBOSE: PowerShell: 5.1.26100.7462
-# VERBOSE: Python: D:\...\wine-assistant\.venv\Scripts\python.exe
-# VERBOSE: Command: "..." -m scripts.mark_stale_import_runs --running-minutes 120 --pending-minutes 15
-# WHATIF: stale detector will NOT be executed.
-# WHATIF: RunningMinutes = 120
-# WHATIF: PendingMinutes = 15
+**Expected output:**
+```
+=== Wine Assistant - Stale Import Runs Detector ===
+Repo root:       D:\...\wine-assistant
+RunningMinutes:  120
+PendingMinutes:  15
 
-# Реальный запуск с диагностикой
+PowerShell: 5.1.26100.7462
+Python: D:\...\wine-assistant\.venv\Scripts\python.exe
+Command:        "D:\...\.venv\Scripts\python.exe" -m scripts.mark_stale_import_runs --running-minutes 120 --pending-minutes 15
+WHATIF: stale detector will NOT be executed.
+WHATIF: command        = "..." -m scripts.mark_stale_import_runs --running-minutes 120 --pending-minutes 15
+WHATIF: RunningMinutes = 120
+WHATIF: PendingMinutes = 15
+```
+
+**Реальный запуск с диагностикой:**
+```powershell
 .\scripts\run_stale_detector.ps1 -RunningMinutes 120 -PendingMinutes 15 -Verbose
+```
 
-# Expected output:
-# Running stale detector...
-# 2025-12-26 08:58:57,299 INFO stale_import_runs_done rolled_back_running=0 rolled_back_pending=0
-# Stale detector completed successfully.
+**Expected output:**
+```
+=== Wine Assistant - Stale Import Runs Detector ===
+Repo root:       D:\...\wine-assistant
+RunningMinutes:  120
+PendingMinutes:  15
 
-# Тихий запуск (без диагностики)
+PowerShell: 5.1.26100.7462
+Python: D:\...\wine-assistant\.venv\Scripts\python.exe
+Command:        "..." -m scripts.mark_stale_import_runs --running-minutes 120 --pending-minutes 15
+Running stale detector...
+
+2025-12-26 08:58:57,299 INFO __main__ stale_import_runs_done rolled_back_running=0 rolled_back_pending=0
+
+Stale detector completed successfully.
+```
+
+**Тихий запуск (без диагностики):**
+```powershell
 .\scripts\run_stale_detector.ps1
 ```
 
@@ -433,6 +479,6 @@ docker compose up -d --force-recreate api
 ---
 
 **Создано:** 04 декабря 2025
-**Обновлено:** 26 декабря 2025 (добавлены Verbose/WhatIf для stale detector)
-**Версия:** 1.4
+**Обновлено:** 26 декабря 2025 (точные примеры вывода для Verbose/WhatIf)
+**Версия:** 1.4-final
 **Для:** Wine Assistant v0.5.0+ (M1 Complete)

--- a/scripts/run_daily_import.ps1
+++ b/scripts/run_daily_import.ps1
@@ -172,7 +172,15 @@ try {
 
   $argStr = (($pyArgs | ForEach-Object { Format-LogArg $_ }) -join " ")
   $cmdStr = ('"{0}" {1}' -f $python, $argStr)
-  Write-Verbose ("Command: {0}" -f $cmdStr)
+
+  # Guarantee a single physical line in logs (no embedded CR/LF).
+  $cmdStr = ($cmdStr -replace "(\r\n|\r|\n)", " ").Trim()
+
+  if ($PSBoundParameters.ContainsKey('Verbose')) {
+    Write-Host ("Command:        {0}" -f $cmdStr)
+  } else {
+    Write-Verbose ("Command: {0}" -f $cmdStr)
+  }
 
   if ($WhatIf) {
     Write-Host ""

--- a/scripts/run_stale_detector.ps1
+++ b/scripts/run_stale_detector.ps1
@@ -55,14 +55,21 @@ try {
 
   $pyArgs = @(
     "-m", "scripts.mark_stale_import_runs",
-    "--running-minutes", $RunningMinutes,
-    "--pending-minutes", $PendingMinutes
+    "--running-minutes", $RunningMinutes.ToString(),
+    "--pending-minutes", $PendingMinutes.ToString()
   )
 
   $argStr = (($pyArgs | ForEach-Object { Format-LogArg $_ }) -join " ")
   $cmdStr = ('"{0}" {1}' -f $python, $argStr)
 
-  Write-Verbose ("Command: {0}" -f $cmdStr)
+  # Guarantee a single physical line in logs (no embedded CR/LF).
+  $cmdStr = ($cmdStr -replace "(\r\n|\r|\n)", " ").Trim()
+
+  if ($PSBoundParameters.ContainsKey('Verbose')) {
+    Write-Host ("Command:        {0}" -f $cmdStr)
+  } else {
+    Write-Verbose ("Command: {0}" -f $cmdStr)
+  }
 
   if ($WhatIf) {
     Write-Host "WHATIF: stale detector will NOT be executed."


### PR DESCRIPTION
## Контекст / проблема
В `run_daily_import.ps1` и `run_stale_detector.ps1` строка с командой (`VERBOSE: Command:`) иногда визуально «ломалась» в консоли и в логах (перенос после `-m` и/или при длинных аргументах). Для дежурного это ухудшало читаемость и усложняло копирование команды из логов.

## Что сделано
### Скрипты
- `scripts/run_daily_import.ps1`
  - Нормализация `$cmdStr`: удаляем любые `CR/LF`, гарантируя **одну физическую строку** в выводе.
  - При запуске с `-Verbose` печатаем `Command:` через `Write-Host` в аккуратно выровненном формате (без `VERBOSE:` префикса), чтобы консоль не вставляла разрывы после `VERBOSE: Command:`.
  - Сохраняем безопасный запуск через массив аргументов (`& $python @pyArgs`).

- `scripts/run_stale_detector.ps1`
  - Аналогичная нормализация `$cmdStr` (однострочный формат).
  - При `-Verbose` печатаем `Command:` через `Write-Host` в том же стиле.
  - Для стабильного join в лог-строке приводим числовые аргументы минут к строкам (`.ToString()`).

### Документация
- `QUICK_REFERENCE.md`
  - Заменены «словесные» описания на **точные примеры вывода** (`-Verbose -WhatIf`) для daily import и stale detector.
  - Добавлены expected output для dry-run и для реального запуска stale detector.
  - Обновлены метаданные версии/даты.

- `docs/runbook_import.md`
  - Добавлены подробные примеры вывода для `run_daily_import.ps1 -Verbose -WhatIf`.
  - Уточнены expected output для stale detector (включая однострочный `Command:`).
  - Отмечено, что команда выводится в одну строку для удобства копирования/логирования.

## Почему это правильно
- Однострочная команда в логах:
  - упрощает копирование/воспроизведение действий дежурным;
  - снижает вероятность ошибки из‑за разрывов строк/переносов.
- Единый стиль вывода между wrapper’ами облегчает поддержку и triage.

## Как тестировалось
- `pre-commit run --all-files` — OK
- `ruff` — OK
- `pytest -q` — **175 passed**
- Ручная проверка вывода:
  - `run_daily_import.ps1 -Verbose -WhatIf` — `Command:` печатается одной строкой
  - `run_stale_detector.ps1 -Verbose -WhatIf` — `Command:` печатается одной строкой

## Заметка по логированию в файл (PowerShell)
`Command:` при `-Verbose` печатается через `Write-Host`, поэтому для захвата «как на экране» используйте:
```powershell
.\scripts\run_stale_detector.ps1 -Verbose -WhatIf *>&1 | Out-File .\_verbose.log -Encoding utf8
```
(или аналогично для `run_daily_import.ps1`).

## Checklist
- [x] Логи команд однострочные и унифицированы
- [x] Документация обновлена и содержит точные примеры вывода
- [x] Тесты зелёные
