### PR TITLE
Ops: DB-backed Daily Import runs registry (Issue #176)

### DIFF
--- a/db/migrations/0015_ops_daily_import_runs.sql
+++ b/db/migrations/0015_ops_daily_import_runs.sql
@@ -1,0 +1,50 @@
+-- db/migrations/0015_ops_daily_import_runs.sql
+-- ============================================================
+-- Ops Daily Import: runs registry (DB-backed history)
+-- Issue: #176
+-- Date: 2026-01-xx
+-- Depends on: 0014_import_runs.sql (update_updated_at_column())
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS public.ops_daily_import_runs (
+  run_id         uuid PRIMARY KEY,
+
+  requested_mode text NOT NULL,          -- 'auto' | 'files'
+  selected_mode  text NULL,              -- e.g. 'AUTO_LATEST' | 'MANUAL_LIST'
+
+  status         text NOT NULL,          -- RUNNING | OK | OK_WITH_SKIPS | FAILED | TIMEOUT | ...
+
+  started_at     timestamptz NOT NULL,
+  finished_at    timestamptz NULL,
+  duration_ms    bigint NULL,
+
+  summary        jsonb NOT NULL DEFAULT '{}'::jsonb,
+
+  -- Full run details payload (same JSON that is stored in FS logs)
+  result_json    jsonb NULL,
+
+  -- Optional pointer to filesystem log location (for artifacts/back-compat)
+  log_relpath    text NULL,
+
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  updated_at     timestamptz NOT NULL DEFAULT now()
+);
+
+-- Keep updated_at in sync (function introduced in 0014_import_runs.sql)
+DROP TRIGGER IF EXISTS tr_ops_daily_import_runs_updated_at ON public.ops_daily_import_runs;
+CREATE TRIGGER tr_ops_daily_import_runs_updated_at
+BEFORE UPDATE ON public.ops_daily_import_runs
+FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- Primary “history feed” index (newest first)
+CREATE INDEX IF NOT EXISTS ix_ops_daily_import_runs_started_desc
+  ON public.ops_daily_import_runs (started_at DESC, run_id DESC);
+
+-- Filtering by status + time window + stable ordering
+CREATE INDEX IF NOT EXISTS ix_ops_daily_import_runs_status_started_desc
+  ON public.ops_daily_import_runs (status, started_at DESC, run_id DESC);
+
+-- Optional: fast lookup of active runs
+CREATE INDEX IF NOT EXISTS ix_ops_daily_import_runs_running
+  ON public.ops_daily_import_runs (started_at DESC, run_id DESC)
+  WHERE status = 'RUNNING';

--- a/tests/unit/test_ops_daily_import_runs_db_registry.py
+++ b/tests/unit/test_ops_daily_import_runs_db_registry.py
@@ -1,0 +1,132 @@
+import json
+from datetime import datetime, timezone
+
+import pytest
+from flask import Flask, jsonify, request
+
+
+@pytest.fixture()
+def ops_client(tmp_path, monkeypatch):
+    from api import ops_daily_import as mod
+
+    # isolate FS
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    monkeypatch.setattr(mod, "LOGS_DIR", logs)
+
+    app = Flask(__name__)
+
+    # minimal API-key gate
+    def require_api_key(fn):
+        def wrapper(*a, **kw):
+            if request.headers.get("X-API-Key") != "testkey":
+                return jsonify({"error": "forbidden"}), 403
+            return fn(*a, **kw)
+        wrapper.__name__ = fn.__name__
+        return wrapper
+
+    class DummyConn:
+        def close(self): pass
+
+    state = {"db_mode": "ok", "calls": 0}
+
+    def db_connect():
+        if state["db_mode"] == "down":
+            return None, "db down"
+        return DummyConn(), None
+
+    def db_query(conn, sql, params=()):
+        if "FROM public.ops_daily_import_runs" in sql and "WHERE run_id" not in sql:
+            # list: return limit+1 rows
+            return [
+                {"run_id": "11111111-1111-1111-1111-111111111111",
+                 "status": "OK",
+                 "requested_mode": "auto",
+                 "selected_mode": "AUTO_LATEST",
+                 "started_at": datetime(2026, 1, 1, tzinfo=timezone.utc),
+                 "finished_at": datetime(2026, 1, 1, tzinfo=timezone.utc),
+                 "duration_ms": 1000,
+                 "summary": {"files_total": 1, "files_imported": 1,
+                             "files_skipped": 0, "files_quarantined": 0,
+                             "files_failed": 0}},
+                {"run_id": "22222222-2222-2222-2222-222222222222",
+                 "status": "OK",
+                 "requested_mode": "auto",
+                 "selected_mode": "AUTO_LATEST",
+                 "started_at": datetime(2025, 12, 31, tzinfo=timezone.utc),
+                 "finished_at": datetime(2025, 12, 31, tzinfo=timezone.utc),
+                 "duration_ms": 900,
+                 "summary": {"files_total": 1, "files_imported": 1,
+                             "files_skipped": 0, "files_quarantined": 0,
+                             "files_failed": 0}},
+                # extra row => next_cursor should exist for limit=2
+                {"run_id": "33333333-3333-3333-3333-333333333333",
+                 "status": "FAILED",
+                 "requested_mode": "files",
+                 "selected_mode": "MANUAL_LIST",
+                 "started_at": datetime(2025, 12, 30, tzinfo=timezone.utc),
+                 "finished_at": datetime(2025, 12, 30, tzinfo=timezone.utc),
+                 "duration_ms": 800,
+                 "summary": {"files_total": 1, "files_imported": 0,
+                             "files_skipped": 0, "files_quarantined": 0,
+                             "files_failed": 1}},
+            ]
+
+        if "FROM public.ops_daily_import_runs" in sql and "WHERE run_id" in sql:
+            return [{
+                "run_id": "33333333-3333-3333-3333-333333333333",
+                "status": "FAILED",
+                "result_json": {
+                    "run_id": "33333333-3333-3333-3333-333333333333",
+                    "status": "FAILED"},
+            }]
+
+        return []
+
+    mod.register_ops_daily_import(app, require_api_key, db_connect, db_query)
+    return app.test_client(), state, logs
+
+def test_runs_list_db_contract_and_next_cursor(ops_client):
+    client, state, _ = ops_client
+    r = client.get("/api/v1/ops/daily-import/runs?limit=2", headers={"X-API-Key":"testkey"})
+    assert r.status_code == 200
+    data = r.get_json()
+
+    # New stable contract
+    assert "items" in data
+    assert len(data["items"]) == 2
+    assert data.get("next_cursor")  # because we returned limit+1
+
+    # Backward compat alias
+    assert "runs" in data
+    assert len(data["runs"]) == 2
+
+def test_run_detail_db_first(ops_client):
+    client, state, _ = ops_client
+    # first call warms state["calls"] for the stub; second call returns run_log
+    client.get("/api/v1/ops/daily-import/runs?limit=2", headers={"X-API-Key":"testkey"})
+    r = client.get("/api/v1/ops/daily-import/runs/33333333-3333-3333-3333-333333333333",
+                   headers={"X-API-Key":"testkey"})
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["run_id"].startswith("33333333")
+    assert data["status"] == "FAILED"
+
+def test_runs_list_fs_fallback_when_db_down(ops_client):
+    client, state, logs = ops_client
+    state["db_mode"] = "down"
+
+    # prepare FS log
+    (logs / "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa.json").write_text(json.dumps({
+        "run_id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "status": "OK",
+        "started_at": "2026-01-01T00:00:00+00:00",
+        "finished_at": "2026-01-01T00:00:01+00:00",
+        "duration_ms": 1000,
+        "summary": {"files_total": 1, "files_imported": 1, "files_skipped": 0, "files_quarantined": 0, "files_failed": 0}
+    }), encoding="utf-8")
+
+    r = client.get("/api/v1/ops/daily-import/runs?limit=50", headers={"X-API-Key":"testkey"})
+    assert r.status_code == 200
+    data = r.get_json()
+    assert data["runs"][0]["run_id"].startswith("aaaaaaaa")


### PR DESCRIPTION
# PR: Ops Daily Import — DB registry для истории запусков (Issue #176)

## Контекст и цель

Ранее история запусков Ops Daily Import хранилась только в файловых логах (`LOGS_DIR/*.json`). Это неудобно для стабильного UI/пагинации/фильтрации и плохо масштабируется (FS как “registry” не даёт гарантий консистентности и усложняет анализ/наблюдаемость).

Цель PR — перевести **историю запусков (runs history)** на **DB-backed registry** с сохранением **FS fallback** на случай недоступности БД и для обратной совместимости.

Связано с:
- Issue #176 — runs history endpoints (перевести с file-log на DB registry)

---

## Что сделано

### 1) Новая таблица реестра запусков
Добавлена миграция:
- `db/migrations/0015_ops_daily_import_runs.sql`

Создаёт `public.ops_daily_import_runs`:
- `run_id UUID PK`
- `requested_mode`, `selected_mode`
- `status`, `started_at`, `finished_at`, `duration_ms`
- `summary JSONB`, `result_json JSONB`
- `log_relpath` (указатель на FS-лог для артефактов/back-compat)
- `created_at`, `updated_at` + trigger на `updated_at`

Индексы:
- по `started_at DESC`
- по `(status, started_at DESC)`
- частичный индекс для `RUNNING` (быстрый поиск активных)

### 2) DB-first для эндпоинтов history (с FS fallback)
В `api/ops_daily_import.py`:
- `GET /api/v1/ops/daily-import/runs`
  - читает из БД (с пагинацией через `cursor`)
  - при недоступности БД — читает из FS логов (как раньше)
  - отдаёт **две формы** ответа:
    - новый контракт: `items` + `next_cursor`
    - back-compat: `runs` (legacy формат)
- `GET /api/v1/ops/daily-import/runs/<run_id>`
  - DB-first (берёт `result_json`, либо минимальный payload из колонок)
  - FS fallback (как раньше)

### 3) Запись старт/финиш в БД с upsert (защита от “потерянных” апдейтов)
- На старте `POST /run` пишется `RUNNING` в FS **и** (best-effort) в БД.
- При завершении background-run запись в БД выполняется через **INSERT ... ON CONFLICT DO UPDATE**:
  - если БД была недоступна на старте (insert не прошёл), то финальный апдейт **не теряется**
  - `started_at` сохраняется как `LEAST(existing, incoming)`
  - `selected_mode` не затирается в `NULL`, если его нет в payload
  - `log_relpath` сохраняется как `COALESCE(existing, incoming)`

---

## Обратная совместимость

- `runs` в ответе `GET /runs` сохранён (legacy контракт).
- FS логи продолжают писаться; при недоступности БД эндпоинты работают через FS fallback.
- В detail (`GET /runs/<run_id>`) при отсутствии `result_json` в БД возвращается минимальный payload (run_id/status/timestamps/summary).

---

## Тестирование

Локально:
- `ruff check .`
- `pytest -q` (все тесты зелёные)

Добавлен unit-тест:
- `tests/unit/test_ops_daily_import_runs_db_registry.py`
  - проверяет DB-first list (items + next_cursor) и наличие legacy `runs`
  - проверяет detail (DB-first)
  - проверяет FS fallback при “db down”

---

## Rollout / заметки по эксплуатации

- После мержа на стенде/локально нужно применить миграции (`make db-migrate` / `db/migrate.ps1`).
- При диагностике проблем истории:
  - смотреть таблицу `public.ops_daily_import_runs`
  - при недоступности БД — API автоматически свалится на FS логи (read-only)

---

## Что НЕ входит в этот PR (следующие шаги)

- Аналогичная запись start/finish в DB для sync-режима запуска (вынести отдельным небольшим PR).
- Возможные улучшения UI/фильтров (status/time window) поверх DB registry.
