### PR TITLE
docs(ops): PowerShell how-to for /run-sync (PS 5.1 vs 7+)

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -7,6 +7,7 @@
 - API:
   - `GET /api/v1/ops/daily-import/inbox`
   - `POST /api/v1/ops/daily-import/run`
+  - `POST /api/v1/ops/daily-import/run-sync`
   - `GET /api/v1/ops/daily-import/runs/<run_id>`
 - CLI / Dev:
   - Makefile: `make daily-import`, `make daily-import-files`, `make daily-import-files-ps`, `make daily-import-history`
@@ -103,6 +104,12 @@
 - HTTP requests примеры
 - JSON parsing
 - Error handling
+
+### [docs/dev/run-sync-powershell.md](docs/dev/run-sync-powershell.md)
+**Как дергать `/api/v1/ops/daily-import/run-sync` из PowerShell (5.1 vs 7+)**
+- Почему `curl.exe --data-raw` может ломать JSON из-за quoting/экранирования
+- Рабочие команды для PS 5.1 и PS 7+
+- Диагностика по ответу `Invalid JSON` (в т.ч. `received_body_tail`)
 
 ### Development Setup
 

--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ $rid = "<run_id>"
 irm "http://localhost:18000/api/v1/ops/daily-import/runs/$rid" -Headers @{ "X-API-Key" = $k } | ConvertTo-Json -Depth 10
 ```
 
+См. также: **[docs/dev/run-sync-powershell.md](docs/dev/run-sync-powershell.md)** — как дергать `POST /api/v1/ops/daily-import/run-sync` из PowerShell (PS 5.1 vs 7+) и почему `curl.exe --data-raw` часто ломает JSON.
+
 Примечание: используйте `docker compose ...` вместо `docker-compose ...`, если в вашей среде нет алиаса `docker-compose` (в проекте есть заметки по этой теме в документации).
 
 ## 🧑‍💻 Developer Docs (для разработчиков)
@@ -733,6 +735,7 @@ make dr-smoke-truncate DR_BACKUP_KEEP=2 MANAGE_PROMTAIL=1
 - **[docs/dev/backup-dr-runbook.md](docs/dev/backup-dr-runbook.md)** — Backup/DR руководство
 - **[docs/dev/web-ui.md](docs/dev/web-ui.md)** — Документация UI
 - **[docs/dev/windows-powershell-http.md](docs/dev/windows-powershell-http.md)** — PowerShell для API
+- **[docs/dev/run-sync-powershell.md](docs/dev/run-sync-powershell.md)** — Как дергать `/run-sync` из PowerShell (5.1 vs 7+)
 
 ---
 

--- a/docs/dev/run-sync-powershell.md
+++ b/docs/dev/run-sync-powershell.md
@@ -1,0 +1,134 @@
+# Как дергать `/run-sync` из PowerShell (Windows PowerShell 5.1 vs PowerShell 7+)
+
+> Endpoint: `POST /api/v1/ops/daily-import/run-sync` (sync, **debug-only**).
+> Для обычной эксплуатации используйте `POST /api/v1/ops/daily-import/run` (async) или `scripts/run_daily_import.ps1`.
+
+## TL;DR
+
+- **Самый надёжный способ (5.1 и 7+):** `Invoke-RestMethod`.
+- **Если нужен именно `curl.exe`:** передавайте body через **stdin** (`--data-binary '@-'`), тогда PowerShell не “ломает” кавычки.
+
+---
+
+## 0) Подготовка переменных (base URL, API key, body)
+
+```powershell
+# База (docker compose по умолчанию: 127.0.0.1:18000 -> 8000)
+$base = "http://localhost:18000"
+$url  = "$base/api/v1/ops/daily-import/run-sync"
+
+# API key из .env (trim + снять кавычки)
+$apiKeyLine = (Get-Content .env | Where-Object { $_ -match '^\s*API_KEY\s*=' } | Select-Object -First 1)
+$apiKey     = ($apiKeyLine -replace '^\s*API_KEY\s*=\s*','').Trim().Trim('"')
+
+# Payload (auto / files)
+$body = @{ mode = "auto"; files = @() } | ConvertTo-Json -Compress
+```
+
+---
+
+## 1) Рекомендуется: `Invoke-RestMethod` (PowerShell 5.1 и 7+)
+
+### mode=auto
+```powershell
+Invoke-RestMethod -Method Post -Uri $url `
+  -Headers @{ "X-API-Key" = $apiKey } `
+  -ContentType "application/json" `
+  -Body $body
+```
+
+### mode=files (файлы должны быть в `data/inbox/`)
+```powershell
+$bodyFiles = @{ mode = "files"; files = @("2025_12_24 Прайс.xlsx") } | ConvertTo-Json -Compress
+
+Invoke-RestMethod -Method Post -Uri $url `
+  -Headers @{ "X-API-Key" = $apiKey } `
+  -ContentType "application/json" `
+  -Body $bodyFiles
+```
+
+---
+
+## 2) `curl.exe`: универсально и без сюрпризов (stdin + `--data-binary '@-'`)
+
+⚠️ В Windows PowerShell 5.1 (а иногда и в 7+) при **inline** body PowerShell может “съесть” двойные кавычки, и сервер увидит не-JSON вида `{mode:auto,files:[]}` → `{"error":"Invalid JSON"}`.
+
+Решение: **передать JSON через stdin**:
+
+```powershell
+# Важно: использовать именно curl.exe (а не алиас curl)
+$body | & "$env:SystemRoot\System32\curl.exe" -sS -i -X POST $url `
+  -H "Content-Type: application/json" `
+  -H "X-API-Key: $apiKey" `
+  --data-binary '@-'
+```
+
+---
+
+## 3) `curl.exe`: без stdin (workaround через экранирование кавычек)
+
+Если очень нужно передать body “как аргументом” (не через stdin), то:
+- сформируйте JSON строкой,
+- **экранируйте** двойные кавычки `"`.
+
+```powershell
+$bodyEsc = $body.Replace('"','\"')
+
+& "$env:SystemRoot\System32\curl.exe" -sS -i -X POST $url `
+  -H "Content-Type: application/json" `
+  -H "X-API-Key: $apiKey" `
+  --data-raw $bodyEsc
+```
+
+---
+
+## 4) Почему `--data-raw '{"mode":"auto","files":[]}'` иногда ломается
+
+Симптом: вы пишете корректный JSON, но сервер отвечает `Invalid JSON`, а в диагностике видно, что пришло `{mode:auto,files:[]}`.
+
+Причина: PowerShell может по-своему интерпретировать кавычки/скобки при передаче аргументов в native process (curl.exe). На практике это чаще всего проявляется в Windows PowerShell 5.1.
+
+✅ “Железобетонные” варианты: `Invoke-RestMethod` или `curl.exe` через stdin (`--data-binary '@-'`).
+
+---
+
+## 5) PowerShell 7+: заметки про argument passing
+
+Если вы на PowerShell 7+ и всё равно видите, что `curl.exe --data-raw $body` “теряет” кавычки:
+
+1) Проверьте, какие правила передачи аргументов активны:
+```powershell
+$PSVersionTable.PSVersion
+$PSNativeCommandArgumentPassing   # может отсутствовать в старых версиях 7.x
+```
+
+2) Не тратьте время на тонкую настройку — используйте **stdin** вариант из раздела 2.
+
+---
+
+## 6) Быстрая диагностика: что реально ушло в curl
+
+```powershell
+$trace = Join-Path $PWD "curl-trace.txt"
+
+& "$env:SystemRoot\System32\curl.exe" -v --trace-ascii $trace -X POST $url `
+  -H "Content-Type: application/json" `
+  -H "X-API-Key: $apiKey" `
+  --data-raw $body
+
+Get-Content $trace -Tail 80
+```
+
+Ожидаемо в trace должно быть что-то вроде:
+- `Content-Length: ...`
+- тело запроса с кавычками: `{"files":[],"mode":"auto"}`
+
+---
+
+## 7) (Опционально) Диагностика на сервере: `received_body_tail`
+
+Endpoint `/run-sync` умеет включать поле `received_body_tail` в ответе 400 (для ускорения отладки), если выставить env:
+
+- для локального запуска: `OPS_DB_REGISTRY_DEBUG=1` (в окружении API контейнера).
+
+> Не включайте это в production: это диагностический режим.


### PR DESCRIPTION
## Что и зачем

После мержа **#200** стало понятно, что в **Windows PowerShell 5.1** вызов `curl.exe --data-raw` нередко ломает JSON-кавычки, и сервер получает не-JSON вроде:

```text
{files:[],mode:auto}
```

В итоге `/api/v1/ops/daily-import/run-sync` возвращает `400 Invalid JSON`, хотя команда визуально выглядит корректной.

Этот PR добавляет **короткую, практичную памятку** по вызову `/run-sync` из PowerShell (PS 5.1 vs 7+) и делает её видимой из README/INDEX.


## Что изменилось

- Добавлен документ: `docs/dev/run-sync-powershell.md`
  - причины, почему `curl.exe --data-raw` может «съедать» кавычки (особенно в PS 5.1 / при текущем режиме аргументов)
  - рабочие примеры:
    - `Invoke-RestMethod` (универсально)
    - `curl.exe` через pipe + `--data-binary '@-'`
  - как интерпретировать `Invalid JSON` (в т.ч. поле `received_body_tail`, если включён debug)

- Обновлены ссылки в документации:
  - `README.md` — ссылка “См. также … run-sync-powershell.md” рядом с примерами вызова ops endpoints
  - `INDEX.md` — добавлен `/run-sync` в список API и добавлен пункт со ссылкой на новый документ


## Почему так

- Это **документационный** PR, без изменения бизнес-логики импорта.
- Цель — снизить friction при ручном запуске `run-sync` на Windows, где “PowerShell + curl.exe” ведёт себя иначе, чем ожидают пользователи Linux/macOS.


## Как проверить

Локально (Windows):

1) Подними сервисы:
```powershell
docker compose up -d --build api
```

2) Проверь, что через `Invoke-RestMethod` всё ок:
```powershell
$base = "http://localhost:18000"
$url  = "$base/api/v1/ops/daily-import/run-sync"
$apiKey = (Get-Content .env | ? { $_ -match '^\s*API_KEY\s*=' } | Select -First 1) -replace '^\s*API_KEY\s*=\s*',''
$apiKey = $apiKey.Trim().Trim('"')

$body = @{ mode="auto"; files=@() } | ConvertTo-Json -Compress
Invoke-RestMethod -Method Post -Uri $url -Headers @{ "X-API-Key" = $apiKey } -ContentType "application/json" -Body $body
```

3) Проверь “ломающийся” кейс (ожидаемо `400 Invalid JSON`):
```powershell
& "$env:SystemRoot\System32\curl.exe" -i -X POST $url -H "Content-Type: application/json" -H "X-API-Key: $apiKey" --data-raw $body
```

4) Проверь “правильный” `curl.exe` через pipe (ожидаемо `200 OK`):
```powershell
$body | & "$env:SystemRoot\System32\curl.exe" -i -X POST $url -H "Content-Type: application/json" -H "X-API-Key: $apiKey" --data-binary '@-'
```


## Риски и обратная совместимость

- Риск минимальный: изменения только в документации/ссылках.
- Backward compatibility не затрагивается.


## Связанные изменения

- #200 — улучшена диагностика `Invalid JSON` для `/run-sync` (PowerShell-friendly).
