### PR TITLE
db(ops): add daily import uploads registry (sha256 inbox dedupe)

### DIFF
--- a/db/migrations/0016_ops_daily_import_uploads.sql
+++ b/db/migrations/0016_ops_daily_import_uploads.sql
@@ -1,0 +1,68 @@
+-- db/migrations/0016_ops_daily_import_uploads.sql
+-- ============================================================
+-- Ops Daily Import: inbox uploads registry (SHA-256 dedupe source of truth)
+-- Issue: #175
+-- Date: 2026-01-xx
+-- Depends on: 0014_import_runs.sql (update_updated_at_column())
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS public.ops_daily_import_uploads (
+  upload_id      uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- Dedupe scope: only within active INBOX
+  status         text NOT NULL DEFAULT 'INBOX'
+    CHECK (status IN ('INBOX', 'ARCHIVED', 'QUARANTINED', 'DELETED')),
+
+  original_name  text NOT NULL,         -- user-provided filename
+  saved_name     text NOT NULL,         -- filesystem name inside INBOX
+
+  -- Truth: content fingerprint
+  sha256         char(64) NOT NULL,
+  size_bytes     bigint NOT NULL CHECK (size_bytes >= 0),
+
+  uploaded_at    timestamptz NOT NULL DEFAULT now(),
+  moved_at       timestamptz NULL,
+
+  -- Future linkage: which run consumed this upload
+  consumed_run_id uuid NULL
+    REFERENCES public.ops_daily_import_runs(run_id) ON DELETE SET NULL,
+
+  metadata       jsonb NOT NULL DEFAULT '{}'::jsonb,
+
+  created_at     timestamptz NOT NULL DEFAULT now(),
+  updated_at     timestamptz NOT NULL DEFAULT now()
+);
+
+-- Keep updated_at in sync (function introduced in 0014_import_runs.sql)
+DROP TRIGGER IF EXISTS tr_ops_daily_import_uploads_updated_at ON public.ops_daily_import_uploads;
+CREATE TRIGGER tr_ops_daily_import_uploads_updated_at
+BEFORE UPDATE ON public.ops_daily_import_uploads
+FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- =========================
+-- Uniqueness / indexes
+-- =========================
+
+-- Truth: one content (sha256) can exist only once in active inbox
+CREATE UNIQUE INDEX IF NOT EXISTS ux_ops_di_uploads_inbox_sha256
+  ON public.ops_daily_import_uploads (sha256)
+  WHERE status = 'INBOX';
+
+-- Prevent name collisions in active inbox (aligns with FS allocator)
+CREATE UNIQUE INDEX IF NOT EXISTS ux_ops_di_uploads_inbox_saved_name
+  ON public.ops_daily_import_uploads (saved_name)
+  WHERE status = 'INBOX';
+
+-- Common read patterns (newest first)
+CREATE INDEX IF NOT EXISTS ix_ops_di_uploads_uploaded_desc
+  ON public.ops_daily_import_uploads (uploaded_at DESC, upload_id DESC);
+
+CREATE INDEX IF NOT EXISTS ix_ops_di_uploads_status_uploaded_desc
+  ON public.ops_daily_import_uploads (status, uploaded_at DESC, upload_id DESC);
+
+CREATE INDEX IF NOT EXISTS ix_ops_di_uploads_consumed_run_id
+  ON public.ops_daily_import_uploads (consumed_run_id)
+  WHERE consumed_run_id IS NOT NULL;
+
+COMMENT ON TABLE public.ops_daily_import_uploads IS
+  'Ops Daily Import uploads registry. Dedupe truth: sha256. Enforced only for INBOX via partial unique index.';


### PR DESCRIPTION
# PR: DB — реестр загрузок для Ops Daily Import (истина: SHA-256, dedupe в INBOX)

## Контекст

Это PR-2 из пакета по Issue **#175**.  
После PR-1 dedupe по SHA-256 реализован на уровне API (best-effort, без БД).  
Этот PR добавляет **DB-реестр загрузок** и “рельсы” для строгой идемпотентности на уровне БД.

---

## Что сделано

Добавлена миграция:

- `db/migrations/0016_ops_daily_import_uploads.sql`

Она создаёт таблицу:

- `public.ops_daily_import_uploads`

и набор индексов/ограничений.

---

## Модель истины / семантика

- **`sha256` — канонический идентификатор контента.**
- “Дубликат” определяется как **совпадение `sha256`**.
- Dedupe ограничен **только активным INBOX** (как и в PR-1):  
  обеспечивается **partial unique index** `WHERE status = 'INBOX'`.

`size_bytes` хранится как атрибут (диагностика/аудит), **не участвует** в уникальности.

---

## Схема (кратко)

Таблица `ops_daily_import_uploads` содержит:

- `upload_id` (UUID, PK)
- `status` (`INBOX | ARCHIVED | QUARANTINED | DELETED`)
- `original_name` (исходное имя)
- `saved_name` (фактическое имя в FS inbox)
- `sha256` (char(64))
- `size_bytes` (bigint)
- `uploaded_at`, `moved_at`
- `consumed_run_id` (FK -> `ops_daily_import_runs.run_id`, optional)
- `metadata` (jsonb)
- `created_at`, `updated_at` (+ trigger `update_updated_at_column()`)

---

## Индексы / уникальность

- `ux_ops_di_uploads_inbox_sha256` — **UNIQUE (sha256) WHERE status='INBOX'**
- `ux_ops_di_uploads_inbox_saved_name` — **UNIQUE (saved_name) WHERE status='INBOX'**
- Индексы для выборок “новые сверху”:
  - `ix_ops_di_uploads_uploaded_desc`
  - `ix_ops_di_uploads_status_uploaded_desc`
- Индекс по `consumed_run_id` (частичный)

---

## Почему так

- Совпадает с текущей политикой PR-1 (dedupe “в рамках INBOX”).
- Подготавливает следующий PR (API после PR-2):
  - `INSERT ... ON CONFLICT DO NOTHING RETURNING upload_id`
  - при конфликте: lookup по `sha256` и формирование `rejected: DUPLICATE` без файлового сканирования inbox.

---

## Как проверить локально

```powershell
.\db\migrate.ps1
docker compose exec -T db psql -U postgres -d wine_db -c "\d+ public.ops_daily_import_uploads"
docker compose exec -T db psql -U postgres -d wine_db -c "SELECT indexname, indexdef FROM pg_indexes WHERE schemaname='public' AND tablename='ops_daily_import_uploads' ORDER BY indexname;"
```

Ожидается наличие таблицы и индексов `ux_ops_di_uploads_inbox_sha256` / `ux_ops_di_uploads_inbox_saved_name`.

---

## Следующий шаг (отдельный PR)

- Перевести upload API на DB-истину:
  - запись в `ops_daily_import_uploads` через `INSERT ... ON CONFLICT`
  - `duplicate_of` получать из БД (без сканирования файловой системы)
