### PR TITLE
tests: prefer .env locally (keep CI env authoritative)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,10 @@ from flask import Flask
 try:
     from dotenv import load_dotenv
 
-    load_dotenv(override=False)
+    # В локальной разработке лучше предпочесть .env, чтобы не "протекали" старые PG* из окружения.
+    # В CI окружение должно быть источником истины.
+    override = os.getenv("CI") not in ("1", "true", "True")
+    load_dotenv(override=override)
 except Exception:
     # python-dotenv is optional; tests can still run if env vars are provided by the shell/CI.
     pass


### PR DESCRIPTION
# PR: Tests — предпочитать `.env` локально (CI остаётся источником истины)

## Контекст / проблема

Локально интеграционные тесты иногда падали с:

- `FATAL: password authentication failed for user "postgres"`

Причина: в `tests/conftest.py` использовалось `load_dotenv(override=False)`, из-за чего
**старые `PG*` переменные** (например, `PGPASSWORD`) могли “протекать” из окружения PowerShell/IDE и
перекрывать значения из `.env`. В CI при этом окружение должно оставаться источником истины.

---

## Что сделано

В `tests/conftest.py` изменена логика загрузки `.env`:

- **локально** (`CI` не выставлен) — `load_dotenv(override=True)`:
  - `.env` становится источником истины для `PG*`, тестовый запуск детерминированный
- **в CI** (`CI=1/true/True`) — `load_dotenv(override=False)`:
  - переменные окружения CI не затираются `.env`

---

## Изменённый код (суть)

```python
override = os.getenv("CI") not in ("1", "true", "True")
load_dotenv(override=override)
```

---

## Почему это безопасно

- CI поведение не меняем: окружение CI остаётся authoritative.
- Локальные тесты становятся воспроизводимыми: `.env` “побеждает” случайные наследованные `PG*`.

---

## Как проверить

Локально:

1) Убедиться, что в `.env` корректные `PGHOST/PGPORT/PGUSER/PGPASSWORD/PGDATABASE`.
2) Запустить:
```powershell
pytest -q
```

Проверка, что “протечки” больше не влияют:
- можно намеренно выставить неверный `PGPASSWORD` в окружении и убедиться, что `.env` его переопределяет.

---

## Не входит в PR

- Никаких изменений в прод-коде, миграциях, API — только тестовая инфраструктура.
