### PR TITLE
Ops: safe daily-import-housekeeping (Issue #181)

### DIFF
--- a/docs/ops_housekeeping.md
+++ b/docs/ops_housekeeping.md
@@ -1,0 +1,75 @@
+# Ops: Daily Import housekeeping
+
+Цель: безопасная ретенция (housekeeping) файлов в директориях Daily Import.
+
+## Что чистим
+
+Зоны:
+
+- inbox: `data/inbox`
+- archive: `data/archive`
+- quarantine: `data/quarantine`
+- logs: `data/logs/daily-import`
+
+Критерий отбора: `mtime` файла (UTC). Удаляются только **файлы** (директории не трогаем).
+`.gitkeep` игнорируется.
+
+## Safety model
+
+- По умолчанию: **dry-run** (ничего не удаляет), только печатает план.
+- Для фактического удаления нужен флаг `--apply` (или `APPLY=1` в make).
+- Guardrail `min-age-days` (по умолчанию 7): если среди кандидатов есть файлы моложе `min-age-days`,
+  то без `--force` удаление запрещено (ошибка, exit code 2).
+
+## Make targets
+
+Единая команда:
+
+```bash
+make daily-import-housekeeping
+```
+
+Параметры (0 = зона отключена):
+
+- `DAYS_INBOX`
+- `DAYS_ARCHIVE`
+- `DAYS_QUARANTINE`
+- `DAYS_LOGS`
+- `HK_MIN_AGE_DAYS` (default: 7)
+- `APPLY=1` — выполнить удаление
+- `FORCE=1` — обойти safety guard
+
+Примеры:
+
+Dry-run (только план):
+
+```bash
+make daily-import-housekeeping DAYS_ARCHIVE=90
+```
+
+Apply:
+
+```bash
+make daily-import-housekeeping DAYS_ARCHIVE=90 APPLY=1
+```
+
+Apply + force:
+
+```bash
+make daily-import-housekeeping DAYS_ARCHIVE=90 APPLY=1 FORCE=1
+```
+
+Deprecated alias:
+
+```bash
+make daily-import-cleanup-archive DAYS=90
+make daily-import-cleanup-archive DAYS=90 APPLY=1
+```
+
+## Direct CLI usage
+
+```bash
+python -m scripts.ops_housekeeping --days-archive 90
+python -m scripts.ops_housekeeping --days-archive 90 --apply
+python -m scripts.ops_housekeeping --days-archive 90 --apply --force
+```

--- a/scripts/ops_housekeeping.py
+++ b/scripts/ops_housekeeping.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+IGNORE_NAMES = {".gitkeep"}
+
+
+@dataclass(frozen=True)
+class Candidate:
+    path: Path
+    mtime: datetime
+    size_bytes: int
+
+
+def select_candidates(base_dir: Path, *, older_than_days: int, now: datetime) -> list[Candidate]:
+    """
+    Возвращает файлы старше older_than_days, рекурсивно.
+    Ничего не удаляет. Только план.
+
+    Правила:
+      - older_than_days <= 0 => пустой список
+      - учитываем только файлы (не директории)
+      - пропускаем IGNORE_NAMES
+      - mtime сравниваем в UTC
+      - результат сортируем стабильно по path (posix)
+    """
+    if older_than_days <= 0:
+        return []
+
+    if now.tzinfo is None:
+        raise ValueError("now must be timezone-aware")
+
+    if not base_dir.exists():
+        return []
+
+    cutoff = now - timedelta(days=older_than_days)
+    out: list[Candidate] = []
+
+    for p in base_dir.rglob("*"):
+        if not p.is_file():
+            continue
+        if p.name in IGNORE_NAMES:
+            continue
+
+        st = p.stat()
+        mtime = datetime.fromtimestamp(st.st_mtime, tz=timezone.utc)
+        if mtime < cutoff:
+            out.append(Candidate(path=p, mtime=mtime, size_bytes=st.st_size))
+
+    out.sort(key=lambda c: c.path.as_posix())
+    return out
+
+
+def _fmt_bytes(n: int) -> str:
+    # простой человекочитаемый формат, без внешних зависимостей
+    units = ["B", "KB", "MB", "GB", "TB"]
+    v = float(n)
+    for u in units:
+        if v < 1024.0 or u == units[-1]:
+            if u == "B":
+                return f"{int(v)} {u}"
+            return f"{v:.1f} {u}"
+        v /= 1024.0
+    return f"{n} B"
+
+
+def _zone_plan(
+    zone_name: str,
+    base_dir: Path,
+    *,
+    older_than_days: int,
+    now: datetime,
+) -> tuple[str, list[Candidate]]:
+    candidates = select_candidates(base_dir, older_than_days=older_than_days, now=now)
+    return zone_name, candidates
+
+
+def _min_age_guard(
+    plans: list[tuple[str, list[Candidate]]],
+    *,
+    now: datetime,
+    min_age_days: int,
+) -> list[Candidate]:
+    """Возвращает список файлов, которые моложе min_age_days (т.е. потенциально опасно удалять)."""
+    if min_age_days <= 0:
+        return []
+
+    cutoff = now - timedelta(days=min_age_days)
+    too_young: list[Candidate] = []
+    for _zone, items in plans:
+        for c in items:
+            # c.mtime в UTC; cutoff — tz-aware
+            if c.mtime >= cutoff:
+                too_young.append(c)
+    too_young.sort(key=lambda c: c.path.as_posix())
+    return too_young
+
+
+def _apply_delete(plans: list[tuple[str, list[Candidate]]]) -> int:
+    deleted = 0
+    for _zone, items in plans:
+        for c in items:
+            try:
+                c.path.unlink(missing_ok=True)
+                deleted += 1
+            except FileNotFoundError:
+                # race ok
+                continue
+    return deleted
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="ops_housekeeping",
+        description="Retention / housekeeping for Daily Import directories (dry-run by default).",
+    )
+    parser.add_argument("--days-inbox", type=int, default=0)
+    parser.add_argument("--days-archive", type=int, default=0)
+    parser.add_argument("--days-quarantine", type=int, default=0)
+    parser.add_argument("--days-logs", type=int, default=0)
+
+    parser.add_argument("--apply", action="store_true", help="Actually delete files. Default: dry-run.")
+    parser.add_argument("--force", action="store_true", help="Bypass safety guards.")
+    parser.add_argument("--min-age-days", type=int, default=7, help="Safety: do not delete files newer than this without --force.")
+    parser.add_argument("--limit", type=int, default=20, help="Limit printed paths per zone.")
+
+    args = parser.parse_args(argv)
+
+    now = datetime.now(timezone.utc)
+
+    zones: list[tuple[str, Path, int]] = [
+        ("inbox", Path("data/inbox"), args.days_inbox),
+        ("archive", Path("data/archive"), args.days_archive),
+        ("quarantine", Path("data/quarantine"), args.days_quarantine),
+        ("logs", Path("data/logs/daily-import"), args.days_logs),
+    ]
+
+    plans: list[tuple[str, list[Candidate]]] = []
+    for name, base_dir, days in zones:
+        if days <= 0:
+            continue
+        plans.append(_zone_plan(name, base_dir, older_than_days=days, now=now))
+
+    total_files = sum(len(items) for _z, items in plans)
+    total_bytes = sum(c.size_bytes for _z, items in plans for c in items)
+
+    mode = "APPLY" if args.apply else "DRY-RUN"
+    print(f"housekeeping mode={mode} now_utc={now.isoformat()} zones={len(plans)}")
+    print(f"total candidates: {total_files} files, {_fmt_bytes(total_bytes)}")
+
+    for zone, items in plans:
+        z_bytes = sum(c.size_bytes for c in items)
+        print(f"\n[{zone}] candidates: {len(items)} files, {_fmt_bytes(z_bytes)}")
+        for c in items[: max(args.limit, 0)]:
+            print(f"  {c.path.as_posix()}  mtime={c.mtime.isoformat()}  size={c.size_bytes}")
+
+        if args.limit >= 0 and len(items) > args.limit:
+            print(f"  ... ({len(items) - args.limit} more)")
+
+    if args.apply:
+        too_young = _min_age_guard(plans, now=now, min_age_days=args.min_age_days)
+        if too_young and not args.force:
+            print(
+                f"\nERROR: safety guard triggered: {len(too_young)} candidate files are newer than min_age_days={args.min_age_days}.",
+                file=sys.stderr,
+            )
+            print("Refusing to delete. Re-run with --force to bypass.", file=sys.stderr)
+            return 2
+
+        deleted = _apply_delete(plans)
+        print(f"\nDELETED: {deleted} files")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_ops_housekeeping.py
+++ b/tests/unit/test_ops_housekeeping.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+from scripts.ops_housekeeping import IGNORE_NAMES, select_candidates
+
+
+def _set_mtime(path: Path, *, dt_utc: datetime) -> None:
+    # os.utime expects POSIX timestamp (float seconds)
+    ts = dt_utc.timestamp()
+    os.utime(path, (ts, ts))
+
+
+def test_select_candidates_filters_by_age(tmp_path: Path) -> None:
+    base = tmp_path / "archive"
+    base.mkdir()
+
+    now = datetime(2026, 2, 8, 0, 0, 0, tzinfo=timezone.utc)
+
+    old_file = base / "old.txt"
+    new_file = base / "new.txt"
+    old_file.write_text("old", encoding="utf-8")
+    new_file.write_text("new", encoding="utf-8")
+
+    # older_than_days=10 => cutoff = now - 10 days
+    # make old_file 20 days old, new_file 2 days old
+    _set_mtime(old_file, dt_utc=datetime(2026, 1, 19, 0, 0, 0, tzinfo=timezone.utc))
+    _set_mtime(new_file, dt_utc=datetime(2026, 2, 6, 0, 0, 0, tzinfo=timezone.utc))
+
+    got = select_candidates(base, older_than_days=10, now=now)
+    got_paths = [c.path.name for c in got]
+
+    assert got_paths == ["old.txt"]
+
+
+def test_select_candidates_ignores_gitkeep(tmp_path: Path) -> None:
+    base = tmp_path / "inbox"
+    base.mkdir()
+
+    now = datetime(2026, 2, 8, 0, 0, 0, tzinfo=timezone.utc)
+
+    gitkeep_name = next(iter(IGNORE_NAMES))
+    gitkeep = base / gitkeep_name
+    gitkeep.write_text("", encoding="utf-8")
+    _set_mtime(gitkeep, dt_utc=datetime(2020, 1, 1, 0, 0, 0, tzinfo=timezone.utc))
+
+    got = select_candidates(base, older_than_days=1, now=now)
+    assert got == []


### PR DESCRIPTION
- Added \`make daily-import-housekeeping\` (dry-run by default, \`APPLY=1\` to delete)
- Implemented \`scripts/ops_housekeeping.py\` with safety guard (\`--min-age-days\`, \`--force\`)
- Deprecated \`daily-import-cleanup-archive\` (no silent delete)
- Added docs: \`docs/ops_housekeeping.md\`
- Added unit tests for candidate selection

## Testing
- make lint
- make test
- python -m scripts.ops_housekeeping --days-archive 1

Closes #181.